### PR TITLE
feat/graph-data-builder — transform courses into React Flow nodes and edges

### DIFF
--- a/src/utils/graphDataBuilder.js
+++ b/src/utils/graphDataBuilder.js
@@ -1,0 +1,46 @@
+// src/utils/graphDataBuilder.js
+
+// TASK 2 — Auto-positioning helper
+// Groups courses by yearLevel and stacks them vertically within each group
+function getPosition(course, allCourses) {
+  const coursesInSameYear = allCourses.filter(
+    (c) => c.yearLevel === course.yearLevel
+  );
+  const indexWithinGroup = coursesInSameYear.findIndex(
+    (c) => c.courseCode === course.courseCode
+  );
+  return {
+    x: course.yearLevel * 250,
+    y: indexWithinGroup * 120,
+  };
+}
+
+// TASK 1 — Main buildGraphData() function
+export function buildGraphData(courses) {
+  // Build nodes — one per course
+  const nodes = courses.map((course) => ({
+    id: course.courseCode,
+    data: {
+      courseCode: course.courseCode,
+      courseTitle: course.courseTitle,
+      yearLevel: course.yearLevel,
+    },
+    position: getPosition(course, courses),
+  }));
+
+  // Build edges — one per prerequisite link
+  const edges = [];
+  courses.forEach((course) => {
+    if (course.prerequisites && course.prerequisites.length > 0) {
+      course.prerequisites.forEach((prereqCode) => {
+        edges.push({
+          id: `${prereqCode}-${course.courseCode}`,
+          source: prereqCode,
+          target: course.courseCode,
+        });
+      });
+    }
+  });
+
+  return { nodes, edges };
+}


### PR DESCRIPTION
Manual test results:
- Nodes: 10 entries (one per active course) ✅
- Edges: 10 entries with correct prerequisite links ✅
- Sample edges: CS101→CS102, CS102→CS201, CS201→CS302, CS302→CS401 ✅
- Node count matches seeded courses: 10 ✅
- No orphaned edge references ✅

<img width="1919" height="903" alt="image" src="https://github.com/user-attachments/assets/fe71a954-2646-46a6-a599-35e5a1cdaf73" />

