### PR TITLE
feat: build SoftDisableConfirmDialog with soft-disable flow

### DIFF
--- a/src/components/SoftDisableConfirmDialog.jsx
+++ b/src/components/SoftDisableConfirmDialog.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { disableCourse } from '../services/courseService';
+import '../styles/ConfirmDialog.css';
+
+export default function SoftDisableConfirmDialog({
+  isOpen,
+  onClose,
+  onDisabled,
+  courseId,
+  courseCode
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleConfirmDisable = async () => {
+    if (!courseId) return;
+
+    setLoading(true);
+    setError('');
+
+    try {
+      // Call disableCourse — this sets isActive: false
+      await disableCourse(courseId);
+      
+      // Success: notify parent to refresh the list
+      onDisabled();
+      
+      // Close dialog
+      onClose();
+    } catch (err) {
+      setError(`Failed to disable course: ${err.message}`);
+      console.error('Disable course error:', err);
+      setLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setError('');
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="dialog-overlay" onClick={handleCancel}>
+      <div className="dialog-box" onClick={e => e.stopPropagation()}>
+        <div className="dialog-icon warning">⚠</div>
+        
+        <h3 className="dialog-title">Disable Course?</h3>
+        
+        <p className="dialog-message">
+          Are you sure you want to remove <strong>{courseCode}</strong> from the curriculum map?
+        </p>
+        
+        <p className="dialog-subtitle">
+          This action can be undone by an administrator.
+        </p>
+
+        {error && <div className="error-message">{error}</div>}
+
+        <div className="dialog-actions">
+          <button
+            onClick={handleCancel}
+            className="btn-cancel"
+            disabled={loading}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirmDisable}
+            className="btn-confirm-danger"
+            disabled={loading}
+          >
+            {loading ? 'Disabling...' : 'Confirm Disable'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/CourseListPage.jsx
+++ b/src/pages/CourseListPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import AddCourseModal from '../components/AddCourseModal';
 import EditCourseModal from '../components/EditCourseModal';
+import SoftDisableConfirmDialog from '../components/SoftDisableConfirmDialog';
 import { getCourses } from '../services/courseService';
 
 export default function CourseListPage() {
@@ -8,6 +9,7 @@ export default function CourseListPage() {
   const [loading, setLoading] = useState(true);
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [editingCourse, setEditingCourse] = useState(null);
+  const [disablingCourse, setDisablingCourse] = useState(null);
 
   // Fetch courses on mount
   useEffect(() => {
@@ -33,6 +35,12 @@ export default function CourseListPage() {
 
   // Refresh courses after update
   const handleCourseUpdated = () => {
+    fetchCourses();
+  };
+
+  // Refresh courses after disable
+  const handleCourseDisabled = () => {
+    setDisablingCourse(null);
     fetchCourses();
   };
 
@@ -80,12 +88,20 @@ export default function CourseListPage() {
                       : 'None'}
                   </td>
                   <td>
-                    <button
-                      className="btn-edit"
-                      onClick={() => setEditingCourse(course)}
-                    >
-                      Edit
-                    </button>
+                    <div className="action-buttons">
+                      <button
+                        className="btn-edit"
+                        onClick={() => setEditingCourse(course)}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        className="btn-disable"
+                        onClick={() => setDisablingCourse(course)}
+                      >
+                        Disable
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))}
@@ -109,6 +125,15 @@ export default function CourseListPage() {
         onCourseUpdated={handleCourseUpdated}
         course={editingCourse}
         allCourses={courses}
+      />
+
+      {/* Soft Disable Confirmation Dialog */}
+      <SoftDisableConfirmDialog
+        isOpen={disablingCourse !== null}
+        onClose={() => setDisablingCourse(null)}
+        onDisabled={handleCourseDisabled}
+        courseId={disablingCourse?.id}
+        courseCode={disablingCourse?.courseCode}
       />
     </div>
   );

--- a/src/services/courseService.js
+++ b/src/services/courseService.js
@@ -1,5 +1,3 @@
-// src/services/courseService.js
-
 import { db } from "../lib/firebaseClient.js";
 import {
   collection,
@@ -12,39 +10,79 @@ import {
   serverTimestamp,
 } from "firebase/firestore";
 
-const coursesCollection = collection(db, "courses");
+const COURSES_COLLECTION = "courses";
+const coursesCollection = collection(db, COURSES_COLLECTION);
 
+/**
+ * Get all active courses
+ */
 export async function getCourses() {
-  const q = query(coursesCollection, where("isActive", "==", true));
-  const snapshot = await getDocs(q);
-  return snapshot.docs.map((docSnap) => ({
-    id: docSnap.id,
-    ...docSnap.data(),
-  }));
+  try {
+    const q = query(coursesCollection, where("isActive", "==", true));
+    const snapshot = await getDocs(q);
+
+    return snapshot.docs.map((docSnap) => ({
+      id: docSnap.id,
+      ...docSnap.data(),
+    }));
+  } catch (err) {
+    console.error("Error fetching courses:", err);
+    throw new Error(`Failed to fetch courses: ${err.message}`);
+  }
 }
 
+/**
+ * Add a new course
+ */
 export async function addCourse(courseData) {
-  const docRef = await addDoc(coursesCollection, {
-    ...courseData,
-    isActive: true,
-    createdAt: serverTimestamp(),
-    updatedAt: serverTimestamp(),
-  });
-  return docRef;
+  try {
+    const docRef = await addDoc(coursesCollection, {
+      ...courseData,
+      isActive: true,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    });
+
+    return docRef;
+  } catch (err) {
+    console.error("Error adding course:", err);
+    throw new Error(`Failed to add course: ${err.message}`);
+  }
 }
 
+/**
+ * Update course information
+ */
 export async function updateCourse(id, updatedFields) {
-  const courseDoc = doc(db, "courses", id);
-  await updateDoc(courseDoc, {
-    ...updatedFields,
-    updatedAt: serverTimestamp(),
-  });
+  try {
+    const courseDoc = doc(db, COURSES_COLLECTION, id);
+
+    await updateDoc(courseDoc, {
+      ...updatedFields,
+      updatedAt: serverTimestamp(),
+    });
+  } catch (err) {
+    console.error("Error updating course:", err);
+    throw new Error(`Failed to update course: ${err.message}`);
+  }
 }
 
-export async function disableCourse(id) {
-  const courseDoc = doc(db, "courses", id);
-  await updateDoc(courseDoc, {
-    isActive: false,
-    updatedAt: serverTimestamp(),
-  });
+/**
+ * Disable a course (Soft Delete)
+ * Sets isActive = false instead of removing the document
+ * @param {string} courseId
+ */
+export async function disableCourse(courseId) {
+  try {
+    const courseRef = doc(db, COURSES_COLLECTION, courseId);
+
+    await updateDoc(courseRef, {
+      isActive: false,
+      updatedAt: serverTimestamp(),
+    });
+
+  } catch (err) {
+    console.error("Error disabling course:", err);
+    throw new Error(`Failed to disable course: ${err.message}`);
+  }
 }

--- a/src/styles/ConfirmDialog.css
+++ b/src/styles/ConfirmDialog.css
@@ -1,0 +1,134 @@
+/* Dialog Overlay */
+.dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1001;
+}
+
+/* Dialog Box */
+.dialog-box {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  max-width: 420px;
+  width: 90%;
+  padding: 32px;
+  text-align: center;
+}
+
+/* Icon */
+.dialog-icon {
+  width: 60px;
+  height: 60px;
+  margin: 0 auto 16px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 32px;
+}
+
+.dialog-icon.warning {
+  background-color: #fef3c7;
+  color: #d97706;
+}
+
+.dialog-icon.danger {
+  background-color: #fee2e2;
+  color: #dc2626;
+}
+
+.dialog-icon.success {
+  background-color: #dcfce7;
+  color: #16a34a;
+}
+
+/* Title & Message */
+.dialog-title {
+  margin: 0 0 12px 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.dialog-message {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+  color: #374151;
+  line-height: 1.6;
+}
+
+.dialog-subtitle {
+  margin: 0 0 20px 0;
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 1.6;
+}
+
+.dialog-message strong {
+  color: #1f2937;
+  font-weight: 600;
+}
+
+/* Error Message */
+.error-message {
+  background-color: #fee2e2;
+  color: #dc2626;
+  padding: 12px;
+  border-radius: 6px;
+  margin-bottom: 16px;
+  font-size: 13px;
+  border-left: 4px solid #dc2626;
+}
+
+/* Dialog Actions */
+.dialog-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 24px;
+}
+
+.btn-cancel,
+.btn-confirm-danger {
+  padding: 10px 20px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  transition: background-color 0.2s;
+}
+
+.btn-cancel {
+  background-color: #f3f4f6;
+  color: #374151;
+  min-width: 110px;
+}
+
+.btn-cancel:hover:not(:disabled) {
+  background-color: #e5e7eb;
+}
+
+.btn-confirm-danger {
+  background-color: #dc2626;
+  color: white;
+  min-width: 150px;
+}
+
+.btn-confirm-danger:hover:not(:disabled) {
+  background-color: #b91c1c;
+}
+
+.btn-cancel:disabled,
+.btn-confirm-danger:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/styles/CourseListPage.css
+++ b/src/styles/CourseListPage.css
@@ -92,3 +92,24 @@
   text-align: center;
   color: #6b7280;
 }
+
+.action-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.btn-disable {
+  padding: 6px 12px;
+  background-color: #fee2e2;
+  color: #dc2626;
+  border: 1px solid #fecaca;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.btn-disable:hover {
+  background-color: #fecaca;
+  border-color: #dc2626;
+}


### PR DESCRIPTION
## Manual Testing T-018
 
1. **Run the app:** `npm run dev`
2. **Navigate to:** `/courses`
3. **Test Disable Flow:**
   - Click "Disable" on any course
   - Confirmation dialog should appear with course code
   - Click "Confirm Disable"
   - Course should immediately disappear from the table
4. **Verify in Firestore:**
   - Go to Firebase Console → Firestore
   - Find the disabled course document
   - Confirm: document still exists, `isActive` is `false`, `updatedAt` is updated
5. **Test Cancel:**
   - Click "Disable" on another course
   - Click "Cancel"
   - Dialog closes, course remains in table
6. **Important:** Confirm the component NEVER calls `deleteDoc()` — only `updateDoc()` with `isActive: false`

** SoftDeleteDiaglog**
<img width="1315" height="694" alt="Screenshot 2026-04-08 225411" src="https://github.com/user-attachments/assets/7b11e151-932f-4aa4-8304-f0adcd52f9e1" />
