### PR TITLE
feat: build basic CourseMapPage with year-level and semester grouping

### DIFF
--- a/src/components/AddCourseModal.jsx
+++ b/src/components/AddCourseModal.jsx
@@ -221,8 +221,8 @@ export default function AddCourseModal({ isOpen, onClose, onCourseAdded, allCour
                 value={formData.semester}
                 onChange={handleInputChange}
               >
-                <option value="1st">1st Semester</option>
-                <option value="2nd">2nd Semester</option>
+                <option value="1">1st Semester</option>
+                <option value="2">2nd Semester</option>
                 <option value="Summer">Summer</option>
               </select>
             </div>

--- a/src/components/CurriculumMapPage.jsx
+++ b/src/components/CurriculumMapPage.jsx
@@ -1,0 +1,163 @@
+import React, { useState, useEffect } from 'react';
+import { getCourses } from '../services/courseService';
+
+export default function CurriculumMapPage() {
+  const [courses, setCourses] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [debugInfo, setDebugInfo] = useState('');
+
+  useEffect(() => {
+    fetchCourses();
+  }, []);
+
+  const fetchCourses = async () => {
+    try {
+      setLoading(true);
+      
+      // Step 1: Test if getCourses exists
+      console.log('🔍 STEP 1: Calling getCourses()...');
+      alert('🔍 STEP 1: Calling getCourses()...');
+      
+      const result = await getCourses();
+      
+      // Step 2: Check what we got back
+      console.log('📦 STEP 2: Result from getCourses():', result);
+      alert('📦 STEP 2: Got result with length: ' + (result ? result.length : 'null'));
+      
+      if (!result) {
+        setError('getCourses() returned null');
+        setDebugInfo('getCourses() returned null or undefined');
+        setLoading(false);
+        return;
+      }
+
+      if (result.length === 0) {
+        setError('No courses found in Firestore');
+        setDebugInfo('getCourses() returned empty array []');
+        setCourses([]);
+        setLoading(false);
+        return;
+      }
+
+      // Step 3: Log first course to verify structure
+      console.log('🎓 STEP 3: First course:', result[0]);
+      alert('✅ STEP 3: First course code = ' + (result[0]?.courseCode || 'MISSING'));
+
+      setCourses(result);
+      setDebugInfo(`Successfully loaded ${result.length} courses`);
+      setLoading(false);
+    } catch (err) {
+      console.error('❌ ERROR in fetchCourses:', err);
+      alert('❌ ERROR: ' + err.message);
+      setError(err.message);
+      setDebugInfo(`Error: ${err.message}`);
+      setLoading(false);
+    }
+  };
+
+  // DEBUG: Show what's in state
+  return (
+    <div style={{ padding: '20px', fontFamily: 'Arial' }}>
+      <h1>🔍 CURRICULUM MAP — DEBUG MODE</h1>
+      
+      {/* Status Section */}
+      <div style={{ 
+        background: '#f0f0f0', 
+        padding: '15px', 
+        borderRadius: '5px',
+        marginBottom: '20px'
+      }}>
+        <h3>Status:</h3>
+        <p><strong>Loading:</strong> {String(loading)}</p>
+        <p><strong>Error:</strong> {error || 'None'}</p>
+        <p><strong>Number of courses:</strong> {courses.length}</p>
+        <p><strong>Debug Info:</strong> {debugInfo}</p>
+      </div>
+
+      {/* Loading State */}
+      {loading && (
+        <div style={{ background: '#fff3cd', padding: '15px', borderRadius: '5px' }}>
+          <p>⏳ Loading courses...</p>
+        </div>
+      )}
+
+      {/* Error State */}
+      {error && !loading && (
+        <div style={{ background: '#f8d7da', padding: '15px', borderRadius: '5px' }}>
+          <p>❌ Error: {error}</p>
+          <button onClick={fetchCourses} style={{ padding: '8px 16px', marginTop: '10px' }}>
+            🔄 Retry
+          </button>
+        </div>
+      )}
+
+      {/* No Courses State */}
+      {!loading && !error && courses.length === 0 && (
+        <div style={{ background: '#d1ecf1', padding: '15px', borderRadius: '5px' }}>
+          <p>📭 No courses returned from Firestore</p>
+          <p>Check Firebase Console → Firestore → courses collection</p>
+        </div>
+      )}
+
+      {/* Courses List - RAW TABLE */}
+      {!loading && !error && courses.length > 0 && (
+        <div>
+          <h2>✅ Courses Found: {courses.length}</h2>
+          <table border="1" cellPadding="10" style={{ width: '100%', marginTop: '20px' }}>
+            <thead>
+              <tr style={{ background: '#3b82f6', color: 'white' }}>
+                <th>Code</th>
+                <th>Title</th>
+                <th>Year</th>
+                <th>Semester</th>
+                <th>Units</th>
+                <th>Prerequisites</th>
+              </tr>
+            </thead>
+            <tbody>
+              {courses.map((course, idx) => (
+                <tr key={course.id || idx}>
+                  <td><strong>{course.courseCode || '⚠️ MISSING'}</strong></td>
+                  <td>{course.courseTitle || '⚠️ MISSING'}</td>
+                  <td>{course.yearLevel || '⚠️ MISSING'}</td>
+                  <td>{course.semester || '⚠️ MISSING'}</td>
+                  <td>{course.units || '⚠️ MISSING'}</td>
+                  <td>{course.prerequisites?.join(', ') || 'None'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {/* Raw JSON for verification */}
+          <h3 style={{ marginTop: '30px' }}>Raw JSON (First Course):</h3>
+          <pre style={{ 
+            background: '#f4f4f4', 
+            padding: '15px', 
+            borderRadius: '5px',
+            overflow: 'auto'
+          }}>
+            {JSON.stringify(courses[0], null, 2)}
+          </pre>
+        </div>
+      )}
+
+      {/* Manual Refresh Button */}
+      <button 
+        onClick={fetchCourses} 
+        style={{ 
+          padding: '10px 20px', 
+          marginTop: '20px',
+          background: '#28a745',
+          color: 'white',
+          border: 'none',
+          borderRadius: '5px',
+          cursor: 'pointer',
+          fontSize: '16px'
+        }}
+      >
+        🔄 Refresh Data
+      </button>
+    </div>
+  );
+}

--- a/src/components/EditCourseModal.jsx
+++ b/src/components/EditCourseModal.jsx
@@ -220,8 +220,8 @@ export default function EditCourseModal({ isOpen, onClose, onCourseUpdated, cour
                 value={formData.semester}
                 onChange={handleInputChange}
               >
-                <option value="1st">1st Semester</option>
-                <option value="2nd">2nd Semester</option>
+                <option value="1">1st Semester</option>
+                <option value="2">2nd Semester</option>
                 <option value="Summer">Summer</option>
               </select>
             </div>

--- a/src/pages/CurriculumMapPage.jsx
+++ b/src/pages/CurriculumMapPage.jsx
@@ -1,3 +1,282 @@
+import React, { useState, useEffect } from 'react';
+import { getCourses } from '../services/courseService';
+import '../styles/CurriculumMapPage.css';
+
 export default function CurriculumMapPage() {
-  return <h1 className="text-2xl font-bold p-8">Curriculum Map</h1>;
+  const [courses, setCourses] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [groupedCourses, setGroupedCourses] = useState({});
+  const [expandedYears, setExpandedYears] = useState({ 1: true, 2: true, 3: true, 4: true });
+
+  useEffect(() => {
+    fetchAndGroupCourses();
+  }, []);
+
+  const fetchAndGroupCourses = async () => {
+    try {
+      setLoading(true);
+      const fetchedCourses = await getCourses();
+      
+      if (!fetchedCourses || fetchedCourses.length === 0) {
+        setCourses([]);
+        setGroupedCourses(initializeGroupedStructure());
+        setLoading(false);
+        return;
+      }
+
+      setCourses(fetchedCourses);
+      const grouped = groupCoursesByYearAndSemester(fetchedCourses);
+      setGroupedCourses(grouped);
+      setLoading(false);
+    } catch (err) {
+      setError(err.message);
+      setLoading(false);
+    }
+  };
+
+  const initializeGroupedStructure = () => {
+    const grouped = {};
+    for (let year = 1; year <= 4; year++) {
+      grouped[year] = {
+        '1st': [],
+        '2nd': [],
+        'Summer': []
+      };
+    }
+    return grouped;
+  };
+
+  const convertSemesterValue = (semesterValue) => {
+    if (semesterValue === 1 || semesterValue === '1') return '1st';
+    if (semesterValue === 2 || semesterValue === '2') return '2nd';
+    if (semesterValue === 'Summer' || semesterValue === 'summer') return 'Summer';
+    return semesterValue;
+  };
+
+  const groupCoursesByYearAndSemester = (coursesToGroup) => {
+    const grouped = initializeGroupedStructure();
+
+    coursesToGroup.forEach(course => {
+      const year = course.yearLevel || 1;
+      const semesterRaw = course.semester || 1;
+      const semester = convertSemesterValue(semesterRaw);
+      
+      if (grouped[year] && grouped[year][semester] !== undefined) {
+        grouped[year][semester].push(course);
+      }
+    });
+
+    return grouped;
+  };
+
+  const toggleYear = (year) => {
+    setExpandedYears(prev => ({
+      ...prev,
+      [year]: !prev[year]
+    }));
+  };
+
+  const getTotalCourses = () => {
+    let total = 0;
+    Object.values(groupedCourses).forEach(year => {
+      Object.values(year).forEach(semester => {
+        total += semester.length;
+      });
+    });
+    return total;
+  };
+
+  const getTotalUnits = () => {
+    return courses.reduce((sum, c) => sum + (c.units || 0), 0);
+  };
+
+  if (loading) {
+    return (
+      <div className="map-loading">
+        <div className="spinner"></div>
+        <p>Loading curriculum map...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="map-error">
+        <h2>❌ Error Loading Map</h2>
+        <p>{error}</p>
+        <button onClick={fetchAndGroupCourses} className="btn-retry">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const totalCourses = getTotalCourses();
+  if (totalCourses === 0) {
+    return (
+      <div className="map-empty">
+        <h2>📚 No Active Courses</h2>
+        <p>
+          Add courses in the{' '}
+          <a href="/courses" className="link">
+            Course Management
+          </a>
+          {' '}section.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="curriculum-map-page">
+      <div className="map-header">
+        <h1>Curriculum Map</h1>
+        <p className="map-subtitle">Courses organized by year level and semester</p>
+      </div>
+
+      <div className="map-stats">
+        <div className="stat">
+          <span className="stat-label">Total Courses</span>
+          <span className="stat-value">{totalCourses}</span>
+        </div>
+        <div className="stat">
+          <span className="stat-label">Total Units</span>
+          <span className="stat-value">{getTotalUnits()}</span>
+        </div>
+      </div>
+
+      <div className="curriculum-tree">
+        {[1, 2, 3, 4].map(year => {
+          const yearData = groupedCourses[year];
+          const yearHasCourses = 
+            yearData['1st'].length > 0 || 
+            yearData['2nd'].length > 0 || 
+            yearData['Summer'].length > 0;
+          const isExpanded = expandedYears[year];
+
+          return (
+            <div key={year} className="year-block">
+              <div
+                className="year-header"
+                onClick={() => toggleYear(year)}
+              >
+                <span className="year-toggle">
+                  {isExpanded ? '▼' : '▶'}
+                </span>
+                <h2 className="year-title">Year {year}</h2>
+                <span className="year-count">
+                  {yearData['1st'].length + yearData['2nd'].length + yearData['Summer'].length} courses
+                </span>
+              </div>
+
+              {isExpanded && (
+                <div className="year-content">
+                  {['1st', '2nd', 'Summer'].map(semester => {
+                    const semesterCourses = yearData[semester] || [];
+
+                    return (
+                      <div key={`${year}-${semester}`} className="semester-block">
+                        <h3 className="semester-header">
+                          {semester} Semester
+                          <span className="semester-count">
+                            {semesterCourses.length > 0 && `(${semesterCourses.length})`}
+                          </span>
+                        </h3>
+
+                        {semesterCourses.length === 0 ? (
+                          <div className="empty-semester">
+                            No courses scheduled
+                          </div>
+                        ) : (
+                          <table className="courses-table">
+                            <thead>
+                              <tr>
+                                <th className="col-code">Code</th>
+                                <th className="col-title">Title</th>
+                                <th className="col-units">Units</th>
+                                <th className="col-prerequisites">Prerequisites</th>
+                                <th className="col-skills">Skills</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {semesterCourses
+                                .sort((a, b) =>
+                                  a.courseCode.localeCompare(b.courseCode)
+                                )
+                                .map((course, idx) => (
+                                  <tr key={course.id || idx} className="course-row">
+                                    <td className="col-code">
+                                      <strong>{course.courseCode}</strong>
+                                    </td>
+                                    <td className="col-title">
+                                      <div className="course-title-cell">
+                                        <div className="course-name">
+                                          {course.courseTitle}
+                                        </div>
+                                        {course.knowledgeBuilt && (
+                                          <div className="course-knowledge">
+                                            {course.knowledgeBuilt}
+                                          </div>
+                                        )}
+                                      </div>
+                                    </td>
+                                    <td className="col-units">
+                                      <span className="units-badge">
+                                        {course.units}
+                                      </span>
+                                    </td>
+                                    <td className="col-prerequisites">
+                                      {course.prerequisites &&
+                                      course.prerequisites.length > 0 ? (
+                                        <div className="prerequisites-list">
+                                          {course.prerequisites.map(
+                                            (prereq, idx) => (
+                                              <span key={idx} className="prereq-tag">
+                                                {prereq}
+                                              </span>
+                                            )
+                                          )}
+                                        </div>
+                                      ) : (
+                                        <span className="no-prerequisite">—</span>
+                                      )}
+                                    </td>
+                                    <td className="col-skills">
+                                      {course.skillsLearned &&
+                                      course.skillsLearned.length > 0 ? (
+                                        <div className="skills-list">
+                                          {course.skillsLearned.slice(0, 2).map(
+                                            (skill, idx) => (
+                                              <span key={idx} className="skill-badge">
+                                                {skill}
+                                              </span>
+                                            )
+                                          )}
+                                          {course.skillsLearned.length > 2 && (
+                                            <span className="skill-more">
+                                              +{course.skillsLearned.length - 2}
+                                            </span>
+                                          )}
+                                        </div>
+                                      ) : (
+                                        <span className="no-skills">—</span>
+                                      )}
+                                    </td>
+                                  </tr>
+                                ))}
+                            </tbody>
+                          </table>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
 }

--- a/src/styles/CurriculumMapPage.css
+++ b/src/styles/CurriculumMapPage.css
@@ -1,0 +1,518 @@
+.curriculum-map-page {
+  padding: 32px 24px;
+  max-width: 1400px;
+  margin: 0 auto;
+  background-color: #f9fafb;
+  min-height: 100vh;
+}
+
+/* Header */
+.map-header {
+  margin-bottom: 32px;
+}
+
+.map-header h1 {
+  margin: 0 0 8px 0;
+  font-size: 32px;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.map-subtitle {
+  margin: 0;
+  font-size: 14px;
+  color: #6b7280;
+}
+
+/* Stats */
+.map-stats {
+  display: flex;
+  gap: 24px;
+  margin-bottom: 32px;
+  flex-wrap: wrap;
+}
+
+.stat {
+  flex: 1;
+  min-width: 200px;
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.stat-label {
+  font-size: 13px;
+  color: #6b7280;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.stat-value {
+  font-size: 32px;
+  font-weight: 700;
+  color: #3b82f6;
+}
+
+/* Loading State */
+.map-loading {
+  padding: 60px 24px;
+  text-align: center;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #e5e7eb;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 16px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.map-loading p {
+  margin: 0;
+  color: #6b7280;
+  font-size: 16px;
+}
+
+/* Error State */
+.map-error {
+  background: white;
+  border-radius: 8px;
+  padding: 40px;
+  text-align: center;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.map-error h2 {
+  margin: 0 0 12px 0;
+  color: #dc2626;
+  font-size: 20px;
+}
+
+.map-error p {
+  margin: 0 0 20px 0;
+  color: #6b7280;
+}
+
+.btn-retry {
+  padding: 10px 20px;
+  background-color: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.btn-retry:hover {
+  background-color: #2563eb;
+}
+
+/* Empty State */
+.map-empty {
+  background: white;
+  border-radius: 8px;
+  padding: 60px 40px;
+  text-align: center;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.map-empty h2 {
+  margin: 0 0 12px 0;
+  font-size: 20px;
+  color: #1f2937;
+}
+
+.map-empty p {
+  margin: 0;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.link {
+  color: #3b82f6;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+/* Curriculum Tree */
+.curriculum-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* Year Block */
+.year-block {
+  background: white;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.2s;
+}
+
+.year-block:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.year-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  background: linear-gradient(135deg, #3b82f6, #2563eb);
+  color: white;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.2s;
+}
+
+.year-header:hover {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+}
+
+.year-toggle {
+  font-size: 12px;
+  font-weight: bold;
+  min-width: 16px;
+  text-align: center;
+}
+
+.year-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  flex: 1;
+}
+
+.year-count {
+  font-size: 12px;
+  background: rgba(255, 255, 255, 0.3);
+  padding: 4px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.year-content {
+  padding: 0;
+}
+
+/* Semester Block */
+.semester-block {
+  padding: 0;
+  border-top: 1px solid #e5e7eb;
+}
+
+.semester-block:first-of-type {
+  border-top: none;
+}
+
+.semester-header {
+  margin: 0;
+  padding: 12px 16px;
+  background-color: #f3f4f6;
+  font-size: 14px;
+  font-weight: 600;
+  color: #374151;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.semester-count {
+  font-size: 12px;
+  color: #6b7280;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+/* Empty Semester */
+.empty-semester {
+  padding: 20px 16px;
+  text-align: center;
+  color: #9ca3af;
+  font-size: 13px;
+  background: #fafbfc;
+}
+
+/* Courses Table */
+.courses-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.courses-table thead {
+  background-color: #f9fafb;
+}
+
+.courses-table th {
+  padding: 12px 16px;
+  text-align: left;
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+  border-bottom: 1px solid #e5e7eb;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.courses-table tbody tr {
+  border-bottom: 1px solid #e5e7eb;
+  transition: background-color 0.2s;
+}
+
+.courses-table tbody tr:hover {
+  background-color: #f9fafb;
+}
+
+.courses-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+.courses-table td {
+  padding: 12px 16px;
+  font-size: 14px;
+  color: #374151;
+}
+
+/* Column Widths */
+.col-code {
+  width: 80px;
+  min-width: 80px;
+}
+
+.col-title {
+  width: 40%;
+  min-width: 250px;
+}
+
+.col-units {
+  width: 60px;
+  min-width: 60px;
+  text-align: center;
+}
+
+.col-prerequisites {
+  width: 200px;
+  min-width: 150px;
+}
+
+.col-skills {
+  width: 200px;
+  min-width: 150px;
+}
+
+/* Course Row */
+.course-row {
+  background: white;
+}
+
+/* Course Code */
+.col-code strong {
+  color: #1f2937;
+  font-family: 'Monaco', 'Courier New', monospace;
+  font-size: 13px;
+}
+
+/* Course Title Cell */
+.course-title-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.course-name {
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.course-knowledge {
+  font-size: 12px;
+  color: #6b7280;
+  line-height: 1.4;
+  font-style: italic;
+}
+
+/* Units Badge */
+.units-badge {
+  display: inline-block;
+  padding: 4px 8px;
+  background-color: #dbeafe;
+  color: #1e40af;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+/* Prerequisites */
+.prerequisites-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.prereq-tag {
+  display: inline-block;
+  padding: 4px 8px;
+  background-color: #fef3c7;
+  color: #92400e;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.no-prerequisite {
+  color: #d1d5db;
+  font-style: italic;
+}
+
+/* Skills */
+.skills-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+
+.skill-badge {
+  display: inline-block;
+  padding: 4px 8px;
+  background-color: #d1fae5;
+  color: #065f46;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.skill-more {
+  display: inline-block;
+  font-size: 11px;
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.no-skills {
+  color: #d1d5db;
+  font-style: italic;
+}
+
+/* Responsive Design */
+@media (max-width: 1200px) {
+  .col-prerequisites,
+  .col-skills {
+    display: none;
+  }
+
+  .col-title {
+    width: 60%;
+    min-width: 300px;
+  }
+}
+
+@media (max-width: 768px) {
+  .curriculum-map-page {
+    padding: 16px;
+  }
+
+  .map-header h1 {
+    font-size: 24px;
+  }
+
+  .map-stats {
+    flex-direction: column;
+  }
+
+  .stat {
+    min-width: unset;
+  }
+
+  .courses-table {
+    font-size: 12px;
+  }
+
+  .courses-table th,
+  .courses-table td {
+    padding: 8px 12px;
+  }
+
+  .col-code {
+    width: 60px;
+  }
+
+  .col-units {
+    width: 50px;
+  }
+
+  .col-title {
+    width: 50%;
+    min-width: 150px;
+  }
+
+  .course-knowledge {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .curriculum-map-page {
+    padding: 12px;
+  }
+
+  .map-header h1 {
+    font-size: 20px;
+  }
+
+  .year-header {
+    padding: 12px;
+    gap: 8px;
+  }
+
+  .year-title {
+    font-size: 14px;
+  }
+
+  .courses-table {
+    display: block;
+    overflow-x: auto;
+  }
+
+  .col-prerequisites {
+    display: none;
+  }
+
+  .col-skills {
+    display: none;
+  }
+
+  .col-title {
+    width: auto;
+    min-width: 200px;
+  }
+}


### PR DESCRIPTION
## Description
Implements course management feature (T-019):
- Basic CurriculumMapPage with year/semester grouping

## Changes
- Created CurriculumMapPage.jsx with grouped course view
- Added comprehensive styling for all components

## Testing Instructions
1. Navigate to `/courses`
2. Click "+ Add New Course" → fill form → submit
3. Click "Edit" on any course → modify → update
4. Click "Disable" on any course → confirm → verify soft delete in Firestore
5. Navigate to `/map` → verify courses grouped by year/semester
6. Check Firestore Console to verify data integrity

<img width="1919" height="955" alt="Screenshot 2026-04-09 114714" src="https://github.com/user-attachments/assets/64e2615c-95f1-4a5d-a39d-9bd679808c3c" />
