### PR TITLE
feat: apply Tailwind styling to CourseListPage, modals, and SoftDisab…

### DIFF
--- a/src/components/AddCourseModal.jsx
+++ b/src/components/AddCourseModal.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { addCourse } from '../services/courseService';
-import '../styles/Modal.css'; // You'll create this next
 
 export default function AddCourseModal({ isOpen, onClose, onCourseAdded, allCourses }) {
   const [formData, setFormData] = useState({
@@ -17,26 +16,17 @@ export default function AddCourseModal({ isOpen, onClose, onCourseAdded, allCour
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
-  // Handle text/number input changes
   const handleInputChange = (e) => {
     const { name, value } = e.target;
-    setFormData(prev => ({
-      ...prev,
-      [name]: value
-    }));
-    setError(''); // Clear error when user starts typing
+    setFormData(prev => ({ ...prev, [name]: value }));
+    setError('');
   };
 
-  // Handle multi-select for prerequisites
   const handlePrerequisiteChange = (e) => {
     const selected = Array.from(e.target.selectedOptions).map(option => option.value);
-    setFormData(prev => ({
-      ...prev,
-      prerequisites: selected
-    }));
+    setFormData(prev => ({ ...prev, prerequisites: selected }));
   };
 
-  // Handle skills tag input (comma-separated)
   const handleSkillsChange = (e) => {
     const value = e.target.value;
     setFormData(prev => ({
@@ -45,32 +35,16 @@ export default function AddCourseModal({ isOpen, onClose, onCourseAdded, allCour
     }));
   };
 
-  // Validate form data
   const validateForm = () => {
     const { courseCode, courseTitle, units } = formData;
-    
-    if (!courseCode.trim()) {
-      setError('Course Code is required');
-      return false;
-    }
-    
-    if (!courseTitle.trim()) {
-      setError('Course Title is required');
-      return false;
-    }
-    
-    if (!units || units <= 0) {
-      setError('Units must be a positive number');
-      return false;
-    }
-    
+    if (!courseCode.trim()) { setError('Course Code is required'); return false; }
+    if (!courseTitle.trim()) { setError('Course Title is required'); return false; }
+    if (!units || units <= 0) { setError('Units must be a positive number'); return false; }
     return true;
   };
 
-  // Validate prerequisites (no circular dependencies)
   const validatePrerequisites = () => {
     const { prerequisites, courseCode } = formData;
-    
     for (let prereqCode of prerequisites) {
       const prereq = allCourses.find(c => c.courseCode === prereqCode);
       if (prereq && prereq.prerequisites && prereq.prerequisites.includes(courseCode)) {
@@ -78,20 +52,15 @@ export default function AddCourseModal({ isOpen, onClose, onCourseAdded, allCour
         return false;
       }
     }
-    
     return true;
   };
 
-  // Handle form submission
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
-    
     if (!validateForm()) return;
     if (!validatePrerequisites()) return;
-    
     setLoading(true);
-    
     try {
       await addCourse({
         courseCode: formData.courseCode.trim(),
@@ -106,20 +75,16 @@ export default function AddCourseModal({ isOpen, onClose, onCourseAdded, allCour
         createdAt: new Date(),
         updatedAt: new Date()
       });
-      
-      // Success callback
       onCourseAdded();
       handleReset();
       onClose();
     } catch (err) {
       setError(`Failed to add course: ${err.message}`);
-      console.error('Add course error:', err);
     } finally {
       setLoading(false);
     }
   };
 
-  // Reset form to initial state
   const handleReset = () => {
     setFormData({
       courseCode: '',
@@ -134,7 +99,6 @@ export default function AddCourseModal({ isOpen, onClose, onCourseAdded, allCour
     setError('');
   };
 
-  // Handle modal close
   const handleClose = () => {
     handleReset();
     onClose();
@@ -142,85 +106,89 @@ export default function AddCourseModal({ isOpen, onClose, onCourseAdded, allCour
 
   if (!isOpen) return null;
 
+  const inputClass = "w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent";
+  const labelClass = "block text-sm font-medium text-gray-700 mb-1";
+
   return (
-    <div className="modal-overlay" onClick={handleClose}>
-      <div className="modal-content" onClick={e => e.stopPropagation()}>
-        <div className="modal-header">
-          <h2>Add New Course</h2>
-          <button className="close-btn" onClick={handleClose} aria-label="Close">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+        
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <h2 className="text-xl font-bold text-gray-800">Add New Course</h2>
+          <button
+            onClick={handleClose}
+            className="text-gray-400 hover:text-gray-600 text-xl font-bold leading-none"
+            aria-label="Close"
+          >
             ✕
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="course-form">
+        <form onSubmit={handleSubmit} className="px-6 py-5 space-y-5">
+
           {/* Error Message */}
-          {error && <div className="error-message">{error}</div>}
+          {error && (
+            <div className="bg-red-50 border border-red-300 text-red-700 text-sm px-4 py-3 rounded-lg">
+              {error}
+            </div>
+          )}
 
           {/* Row 1: Course Code & Title */}
-          <div className="form-row">
-            <div className="form-group">
-              <label htmlFor="courseCode">Course Code *</label>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className={labelClass}>Course Code <span className="text-red-500">*</span></label>
               <input
-                id="courseCode"
                 type="text"
                 name="courseCode"
                 value={formData.courseCode}
                 onChange={handleInputChange}
                 placeholder="e.g., CS101"
+                className={inputClass}
                 required
               />
             </div>
-            <div className="form-group">
-              <label htmlFor="courseTitle">Course Title *</label>
+            <div>
+              <label className={labelClass}>Course Title <span className="text-red-500">*</span></label>
               <input
-                id="courseTitle"
                 type="text"
                 name="courseTitle"
                 value={formData.courseTitle}
                 onChange={handleInputChange}
                 placeholder="e.g., Intro to Programming"
+                className={inputClass}
                 required
               />
             </div>
           </div>
 
           {/* Row 2: Units, Year Level, Semester */}
-          <div className="form-row">
-            <div className="form-group">
-              <label htmlFor="units">Units *</label>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div>
+              <label className={labelClass}>Units <span className="text-red-500">*</span></label>
               <input
-                id="units"
                 type="number"
                 name="units"
                 value={formData.units}
                 onChange={handleInputChange}
                 placeholder="e.g., 3"
                 min="1"
+                className={inputClass}
                 required
               />
             </div>
-            <div className="form-group">
-              <label htmlFor="yearLevel">Year Level</label>
-              <select
-                id="yearLevel"
-                name="yearLevel"
-                value={formData.yearLevel}
-                onChange={handleInputChange}
-              >
+            <div>
+              <label className={labelClass}>Year Level</label>
+              <select name="yearLevel" value={formData.yearLevel} onChange={handleInputChange} className={inputClass}>
                 <option value="1">Year 1</option>
                 <option value="2">Year 2</option>
                 <option value="3">Year 3</option>
                 <option value="4">Year 4</option>
               </select>
             </div>
-            <div className="form-group">
-              <label htmlFor="semester">Semester</label>
-              <select
-                id="semester"
-                name="semester"
-                value={formData.semester}
-                onChange={handleInputChange}
-              >
+            <div>
+              <label className={labelClass}>Semester</label>
+              <select name="semester" value={formData.semester} onChange={handleInputChange} className={inputClass}>
                 <option value="1">1st Semester</option>
                 <option value="2">2nd Semester</option>
                 <option value="Summer">Summer</option>
@@ -228,15 +196,14 @@ export default function AddCourseModal({ isOpen, onClose, onCourseAdded, allCour
             </div>
           </div>
 
-          {/* Prerequisites Multi-Select */}
-          <div className="form-group full-width">
-            <label htmlFor="prerequisites">Prerequisites</label>
+          {/* Prerequisites */}
+          <div>
+            <label className={labelClass}>Prerequisites</label>
             <select
-              id="prerequisites"
               multiple
               value={formData.prerequisites}
               onChange={handlePrerequisiteChange}
-              className="multi-select"
+              className={`${inputClass} h-32`}
             >
               {allCourses.map(course => (
                 <option key={course.courseCode} value={course.courseCode}>
@@ -244,49 +211,53 @@ export default function AddCourseModal({ isOpen, onClose, onCourseAdded, allCour
                 </option>
               ))}
             </select>
-            <small>Hold Ctrl (or Cmd on Mac) to select multiple courses</small>
+            <p className="text-xs text-gray-500 mt-1">Hold Ctrl / Cmd to select multiple</p>
           </div>
 
-          {/* Skills Learned (Tag Input - Temporary) */}
-          <div className="form-group full-width">
-            <label htmlFor="skillsLearned">Skills Learned</label>
+          {/* Skills Learned */}
+          <div>
+            <label className={labelClass}>Skills Learned</label>
             <input
-              id="skillsLearned"
               type="text"
               value={formData.skillsLearned.join(', ')}
               onChange={handleSkillsChange}
-              placeholder="e.g., Problem Solving, Java, Object-Oriented Design"
-              className="tag-input"
+              placeholder="e.g., Problem Solving, Java, OOP"
+              className={inputClass}
             />
-            <small>Separate skills with commas</small>
+            <p className="text-xs text-gray-500 mt-1">Separate skills with commas</p>
           </div>
 
           {/* Knowledge Built */}
-          <div className="form-group full-width">
-            <label htmlFor="knowledgeBuilt">Knowledge Built</label>
+          <div>
+            <label className={labelClass}>Knowledge Built</label>
             <textarea
-              id="knowledgeBuilt"
               name="knowledgeBuilt"
               value={formData.knowledgeBuilt}
               onChange={handleInputChange}
-              placeholder="Describe the key concepts and knowledge students will gain..."
-              rows="4"
+              placeholder="Describe the key concepts students will gain..."
+              rows="3"
+              className={inputClass}
             />
           </div>
 
-          {/* Form Actions */}
-          <div className="form-actions">
-            <button type="button" onClick={handleClose} className="btn-cancel">
+          {/* Actions */}
+          <div className="flex flex-col sm:flex-row gap-3 pt-2">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="w-full sm:w-auto px-5 py-2.5 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition duration-150 min-h-[44px]"
+            >
               Cancel
             </button>
             <button
               type="submit"
-              className="btn-primary"
               disabled={loading}
+              className="w-full sm:w-auto px-5 py-2.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition duration-150 min-h-[44px] disabled:opacity-60"
             >
               {loading ? 'Adding Course...' : 'Add Course'}
             </button>
           </div>
+
         </form>
       </div>
     </div>

--- a/src/components/EditCourseModal.jsx
+++ b/src/components/EditCourseModal.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { updateCourse } from '../services/courseService';
-import '../styles/Modal.css';
 
 export default function EditCourseModal({ isOpen, onClose, onCourseUpdated, course, allCourses }) {
   const [formData, setFormData] = useState({
@@ -17,7 +16,6 @@ export default function EditCourseModal({ isOpen, onClose, onCourseUpdated, cour
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
-  // Pre-fill form when course prop changes
   useEffect(() => {
     if (course) {
       setFormData({
@@ -34,26 +32,17 @@ export default function EditCourseModal({ isOpen, onClose, onCourseUpdated, cour
     }
   }, [course, isOpen]);
 
-  // Handle text/number input changes
   const handleInputChange = (e) => {
     const { name, value } = e.target;
-    setFormData(prev => ({
-      ...prev,
-      [name]: value
-    }));
+    setFormData(prev => ({ ...prev, [name]: value }));
     setError('');
   };
 
-  // Handle multi-select for prerequisites
   const handlePrerequisiteChange = (e) => {
     const selected = Array.from(e.target.selectedOptions).map(option => option.value);
-    setFormData(prev => ({
-      ...prev,
-      prerequisites: selected
-    }));
+    setFormData(prev => ({ ...prev, prerequisites: selected }));
   };
 
-  // Handle skills tag input (comma-separated)
   const handleSkillsChange = (e) => {
     const value = e.target.value;
     setFormData(prev => ({
@@ -62,32 +51,16 @@ export default function EditCourseModal({ isOpen, onClose, onCourseUpdated, cour
     }));
   };
 
-  // Validate form data
   const validateForm = () => {
     const { courseCode, courseTitle, units } = formData;
-    
-    if (!courseCode.trim()) {
-      setError('Course Code is required');
-      return false;
-    }
-    
-    if (!courseTitle.trim()) {
-      setError('Course Title is required');
-      return false;
-    }
-    
-    if (!units || units <= 0) {
-      setError('Units must be a positive number');
-      return false;
-    }
-    
+    if (!courseCode.trim()) { setError('Course Code is required'); return false; }
+    if (!courseTitle.trim()) { setError('Course Title is required'); return false; }
+    if (!units || units <= 0) { setError('Units must be a positive number'); return false; }
     return true;
   };
 
-  // Validate prerequisites (no circular dependencies)
   const validatePrerequisites = () => {
     const { prerequisites, courseCode } = formData;
-    
     for (let prereqCode of prerequisites) {
       const prereq = allCourses.find(c => c.courseCode === prereqCode);
       if (prereq && prereq.prerequisites && prereq.prerequisites.includes(courseCode)) {
@@ -95,20 +68,15 @@ export default function EditCourseModal({ isOpen, onClose, onCourseUpdated, cour
         return false;
       }
     }
-    
     return true;
   };
 
-  // Handle form submission
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
-    
     if (!validateForm()) return;
     if (!validatePrerequisites()) return;
-    
     setLoading(true);
-    
     try {
       await updateCourse(course.id, {
         courseCode: formData.courseCode.trim(),
@@ -121,19 +89,15 @@ export default function EditCourseModal({ isOpen, onClose, onCourseUpdated, cour
         knowledgeBuilt: formData.knowledgeBuilt.trim(),
         updatedAt: new Date()
       });
-      
-      // Success callback
       onCourseUpdated();
       onClose();
     } catch (err) {
       setError(`Failed to update course: ${err.message}`);
-      console.error('Update course error:', err);
     } finally {
       setLoading(false);
     }
   };
 
-  // Handle modal close
   const handleClose = () => {
     setError('');
     onClose();
@@ -141,85 +105,89 @@ export default function EditCourseModal({ isOpen, onClose, onCourseUpdated, cour
 
   if (!isOpen || !course) return null;
 
+  const inputClass = "w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent";
+  const labelClass = "block text-sm font-medium text-gray-700 mb-1";
+
   return (
-    <div className="modal-overlay" onClick={handleClose}>
-      <div className="modal-content" onClick={e => e.stopPropagation()}>
-        <div className="modal-header">
-          <h2>Edit Course: {formData.courseCode}</h2>
-          <button className="close-btn" onClick={handleClose} aria-label="Close">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <h2 className="text-xl font-bold text-gray-800">Edit Course: <span className="text-blue-600">{formData.courseCode}</span></h2>
+          <button
+            onClick={handleClose}
+            className="text-gray-400 hover:text-gray-600 text-xl font-bold leading-none"
+            aria-label="Close"
+          >
             ✕
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="course-form">
+        <form onSubmit={handleSubmit} className="px-6 py-5 space-y-5">
+
           {/* Error Message */}
-          {error && <div className="error-message">{error}</div>}
+          {error && (
+            <div className="bg-red-50 border border-red-300 text-red-700 text-sm px-4 py-3 rounded-lg">
+              {error}
+            </div>
+          )}
 
           {/* Row 1: Course Code & Title */}
-          <div className="form-row">
-            <div className="form-group">
-              <label htmlFor="courseCode">Course Code *</label>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className={labelClass}>Course Code <span className="text-red-500">*</span></label>
               <input
-                id="courseCode"
                 type="text"
                 name="courseCode"
                 value={formData.courseCode}
                 onChange={handleInputChange}
                 placeholder="e.g., CS101"
+                className={inputClass}
                 required
               />
             </div>
-            <div className="form-group">
-              <label htmlFor="courseTitle">Course Title *</label>
+            <div>
+              <label className={labelClass}>Course Title <span className="text-red-500">*</span></label>
               <input
-                id="courseTitle"
                 type="text"
                 name="courseTitle"
                 value={formData.courseTitle}
                 onChange={handleInputChange}
                 placeholder="e.g., Intro to Programming"
+                className={inputClass}
                 required
               />
             </div>
           </div>
 
           {/* Row 2: Units, Year Level, Semester */}
-          <div className="form-row">
-            <div className="form-group">
-              <label htmlFor="units">Units *</label>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div>
+              <label className={labelClass}>Units <span className="text-red-500">*</span></label>
               <input
-                id="units"
                 type="number"
                 name="units"
                 value={formData.units}
                 onChange={handleInputChange}
                 placeholder="e.g., 3"
                 min="1"
+                className={inputClass}
                 required
               />
             </div>
-            <div className="form-group">
-              <label htmlFor="yearLevel">Year Level</label>
-              <select
-                id="yearLevel"
-                name="yearLevel"
-                value={formData.yearLevel}
-                onChange={handleInputChange}
-              >
+            <div>
+              <label className={labelClass}>Year Level</label>
+              <select name="yearLevel" value={formData.yearLevel} onChange={handleInputChange} className={inputClass}>
                 <option value="1">Year 1</option>
                 <option value="2">Year 2</option>
                 <option value="3">Year 3</option>
                 <option value="4">Year 4</option>
               </select>
             </div>
-            <div className="form-group">
-              <label htmlFor="semester">Semester</label>
-              <select
-                id="semester"
-                name="semester"
-                value={formData.semester}
-                onChange={handleInputChange}
-              >
+            <div>
+              <label className={labelClass}>Semester</label>
+              <select name="semester" value={formData.semester} onChange={handleInputChange} className={inputClass}>
                 <option value="1">1st Semester</option>
                 <option value="2">2nd Semester</option>
                 <option value="Summer">Summer</option>
@@ -227,67 +195,70 @@ export default function EditCourseModal({ isOpen, onClose, onCourseUpdated, cour
             </div>
           </div>
 
-          {/* Prerequisites Multi-Select */}
-          <div className="form-group full-width">
-            <label htmlFor="prerequisites">Prerequisites</label>
+          {/* Prerequisites */}
+          <div>
+            <label className={labelClass}>Prerequisites</label>
             <select
-              id="prerequisites"
               multiple
               value={formData.prerequisites}
               onChange={handlePrerequisiteChange}
-              className="multi-select"
+              className={`${inputClass} h-32`}
             >
               {allCourses
-                .filter(c => c.courseCode !== formData.courseCode) // Don't allow self-reference
+                .filter(c => c.courseCode !== formData.courseCode)
                 .map(course => (
                   <option key={course.courseCode} value={course.courseCode}>
                     {course.courseCode} — {course.courseTitle}
                   </option>
                 ))}
             </select>
-            <small>Hold Ctrl (or Cmd on Mac) to select multiple courses</small>
+            <p className="text-xs text-gray-500 mt-1">Hold Ctrl / Cmd to select multiple</p>
           </div>
 
-          {/* Skills Learned (Tag Input - Temporary) */}
-          <div className="form-group full-width">
-            <label htmlFor="skillsLearned">Skills Learned</label>
+          {/* Skills Learned */}
+          <div>
+            <label className={labelClass}>Skills Learned</label>
             <input
-              id="skillsLearned"
               type="text"
               value={formData.skillsLearned.join(', ')}
               onChange={handleSkillsChange}
-              placeholder="e.g., Problem Solving, Java, Object-Oriented Design"
-              className="tag-input"
+              placeholder="e.g., Problem Solving, Java, OOP"
+              className={inputClass}
             />
-            <small>Separate skills with commas</small>
+            <p className="text-xs text-gray-500 mt-1">Separate skills with commas</p>
           </div>
 
           {/* Knowledge Built */}
-          <div className="form-group full-width">
-            <label htmlFor="knowledgeBuilt">Knowledge Built</label>
+          <div>
+            <label className={labelClass}>Knowledge Built</label>
             <textarea
-              id="knowledgeBuilt"
               name="knowledgeBuilt"
               value={formData.knowledgeBuilt}
               onChange={handleInputChange}
-              placeholder="Describe the key concepts and knowledge students will gain..."
-              rows="4"
+              placeholder="Describe the key concepts students will gain..."
+              rows="3"
+              className={inputClass}
             />
           </div>
 
-          {/* Form Actions */}
-          <div className="form-actions">
-            <button type="button" onClick={handleClose} className="btn-cancel">
+          {/* Actions */}
+          <div className="flex flex-col sm:flex-row gap-3 pt-2">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="w-full sm:w-auto px-5 py-2.5 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition duration-150 min-h-[44px]"
+            >
               Cancel
             </button>
             <button
               type="submit"
-              className="btn-primary"
               disabled={loading}
+              className="w-full sm:w-auto px-5 py-2.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition duration-150 min-h-[44px] disabled:opacity-60"
             >
               {loading ? 'Updating Course...' : 'Update Course'}
             </button>
           </div>
+
         </form>
       </div>
     </div>

--- a/src/components/SoftDisableConfirmDialog.jsx
+++ b/src/components/SoftDisableConfirmDialog.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { disableCourse } from '../services/courseService';
-import '../styles/ConfirmDialog.css';
 
 export default function SoftDisableConfirmDialog({
   isOpen,
@@ -14,22 +13,14 @@ export default function SoftDisableConfirmDialog({
 
   const handleConfirmDisable = async () => {
     if (!courseId) return;
-
     setLoading(true);
     setError('');
-
     try {
-      // Call disableCourse — this sets isActive: false
       await disableCourse(courseId);
-      
-      // Success: notify parent to refresh the list
       onDisabled();
-      
-      // Close dialog
       onClose();
     } catch (err) {
       setError(`Failed to disable course: ${err.message}`);
-      console.error('Disable course error:', err);
       setLoading(false);
     }
   };
@@ -42,34 +33,47 @@ export default function SoftDisableConfirmDialog({
   if (!isOpen) return null;
 
   return (
-    <div className="dialog-overlay" onClick={handleCancel}>
-      <div className="dialog-box" onClick={e => e.stopPropagation()}>
-        <div className="dialog-icon warning">⚠</div>
-        
-        <h3 className="dialog-title">Disable Course?</h3>
-        
-        <p className="dialog-message">
-          Are you sure you want to remove <strong>{courseCode}</strong> from the curriculum map?
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+      <div
+        className="bg-white rounded-xl shadow-xl w-full max-w-md p-6"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Warning Icon & Title */}
+        <div className="flex items-center gap-3 mb-4">
+          <span className="text-3xl">⚠️</span>
+          <h3 className="text-xl font-bold text-gray-800">Disable Course?</h3>
+        </div>
+
+        {/* Message */}
+        <p className="text-gray-600 text-sm mb-2">
+          Are you sure you want to disable{' '}
+          <span className="font-semibold text-gray-900">{courseCode}</span>{' '}
+          from the curriculum map?
         </p>
-        
-        <p className="dialog-subtitle">
+        <p className="text-gray-400 text-xs mb-5">
           This action can be undone by an administrator.
         </p>
 
-        {error && <div className="error-message">{error}</div>}
+        {/* Error */}
+        {error && (
+          <div className="bg-red-50 border border-red-300 text-red-700 text-sm px-4 py-3 rounded-lg mb-4">
+            {error}
+          </div>
+        )}
 
-        <div className="dialog-actions">
+        {/* Action Buttons */}
+        <div className="flex gap-3">
           <button
             onClick={handleCancel}
-            className="btn-cancel"
             disabled={loading}
+            className="flex-1 px-4 py-2.5 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition duration-150 min-h-[44px] disabled:opacity-60"
           >
             Cancel
           </button>
           <button
             onClick={handleConfirmDisable}
-            className="btn-confirm-danger"
             disabled={loading}
+            className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg transition duration-150 min-h-[44px] disabled:opacity-60"
           >
             {loading ? 'Disabling...' : 'Confirm Disable'}
           </button>

--- a/src/pages/CourseListPage.jsx
+++ b/src/pages/CourseListPage.jsx
@@ -11,7 +11,6 @@ export default function CourseListPage() {
   const [editingCourse, setEditingCourse] = useState(null);
   const [disablingCourse, setDisablingCourse] = useState(null);
 
-  // Fetch courses on mount
   useEffect(() => {
     fetchCourses();
   }, []);
@@ -28,76 +27,78 @@ export default function CourseListPage() {
     }
   };
 
-  // Refresh courses after add
-  const handleCourseAdded = () => {
-    fetchCourses();
-  };
-
-  // Refresh courses after update
-  const handleCourseUpdated = () => {
-    fetchCourses();
-  };
-
-  // Refresh courses after disable
+  const handleCourseAdded = () => fetchCourses();
+  const handleCourseUpdated = () => fetchCourses();
   const handleCourseDisabled = () => {
     setDisablingCourse(null);
     fetchCourses();
   };
 
-  if (loading) return <div className="loading">Loading courses...</div>;
+  if (loading) return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="text-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+        <p className="text-gray-500 text-lg">Loading courses...</p>
+      </div>
+    </div>
+  );
 
   return (
-    <div className="course-list-page">
-      <div className="page-header">
-        <h1>Course Management</h1>
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      {/* Page Header */}
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-3xl font-bold text-gray-900">Courses</h1>
         <button
-          className="btn-add-course"
           onClick={() => setIsAddOpen(true)}
+          className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg shadow transition duration-150"
         >
           + Add New Course
         </button>
       </div>
 
-      <div className="courses-table-container">
+      {/* Table */}
+      <div className="overflow-x-auto rounded-lg shadow border border-gray-200">
         {courses.length === 0 ? (
-          <p className="empty-state">No courses yet. Click "Add New Course" to create one.</p>
+          <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+            <span className="text-5xl mb-4">📭</span>
+            <p className="text-lg font-medium">No courses yet.</p>
+            <p className="text-sm">Click "Add New Course" to create one.</p>
+          </div>
         ) : (
-          <table className="courses-table">
-            <thead>
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-100">
               <tr>
-                <th>Code</th>
-                <th>Title</th>
-                <th>Units</th>
-                <th>Year</th>
-                <th>Semester</th>
-                <th>Prerequisites</th>
-                <th>Actions</th>
+                {['Code', 'Title', 'Units', 'Year', 'Semester', 'Prerequisites', 'Actions'].map(header => (
+                  <th key={header} className="px-4 py-3 text-left text-xs font-bold text-gray-600 uppercase tracking-wider">
+                    {header}
+                  </th>
+                ))}
               </tr>
             </thead>
-            <tbody>
-              {courses.map(course => (
-                <tr key={course.id}>
-                  <td>{course.courseCode}</td>
-                  <td>{course.courseTitle}</td>
-                  <td>{course.units}</td>
-                  <td>Year {course.yearLevel}</td>
-                  <td>{course.semester}</td>
-                  <td>
+            <tbody className="bg-white divide-y divide-gray-100">
+              {courses.map((course, index) => (
+                <tr key={course.id} className={index % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                  <td className="px-4 py-3 text-sm font-medium text-gray-900 whitespace-nowrap">{course.courseCode}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{course.courseTitle}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700 whitespace-nowrap">{course.units}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700 whitespace-nowrap">Year {course.yearLevel}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700 whitespace-nowrap">{course.semester}</td>
+                  <td className="px-4 py-3 text-sm text-gray-500">
                     {course.prerequisites && course.prerequisites.length > 0
                       ? course.prerequisites.join(', ')
-                      : 'None'}
+                      : <span className="italic text-gray-400">None</span>}
                   </td>
-                  <td>
-                    <div className="action-buttons">
+                  <td className="px-4 py-3 whitespace-nowrap">
+                    <div className="flex gap-2">
                       <button
-                        className="btn-edit"
                         onClick={() => setEditingCourse(course)}
+                        className="px-3 py-1.5 text-xs font-medium bg-blue-100 text-blue-700 hover:bg-blue-200 rounded-md transition duration-150 min-h-[36px]"
                       >
                         Edit
                       </button>
                       <button
-                        className="btn-disable"
                         onClick={() => setDisablingCourse(course)}
+                        className="px-3 py-1.5 text-xs font-medium bg-red-100 text-red-700 hover:bg-red-200 rounded-md transition duration-150 min-h-[36px]"
                       >
                         Disable
                       </button>
@@ -110,7 +111,6 @@ export default function CourseListPage() {
         )}
       </div>
 
-      {/* Add Course Modal */}
       <AddCourseModal
         isOpen={isAddOpen}
         onClose={() => setIsAddOpen(false)}
@@ -118,7 +118,6 @@ export default function CourseListPage() {
         allCourses={courses}
       />
 
-      {/* Edit Course Modal */}
       <EditCourseModal
         isOpen={editingCourse !== null}
         onClose={() => setEditingCourse(null)}
@@ -127,7 +126,6 @@ export default function CourseListPage() {
         allCourses={courses}
       />
 
-      {/* Soft Disable Confirmation Dialog */}
       <SoftDisableConfirmDialog
         isOpen={disablingCourse !== null}
         onClose={() => setDisablingCourse(null)}


### PR DESCRIPTION
**feat/ui-style-course-pages — Style CourseListPage, modals, and SoftDisable dialog**
Applied Tailwind CSS styling to all course management components.
Changes made:

**CourseListPage:** styled table with headers, alternating row shading, Edit/Disable action buttons, loading spinner, and empty state
**AddCourseModal & EditCourseModal:** styled overlay, white card, form fields, prerequisite multi-select, error messages, and action buttons
**SoftDisableConfirmDialog:** warning icon, clear message, red Confirm Disable button and gray Cancel button side by side

**Manual testing:**

✅ Table loads and displays all active courses
✅ Add Course modal opens, submits, and refreshes the table
✅ Edit Course modal pre-fills existing data correctly
✅ Disable dialog shows correct course code and removes it from the table on confirm
✅ Responsive at 375px mobile — no horizontal overflow

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/36aa1c10-cbde-4697-9f3c-3108ab402bfb" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a0de7fb1-1983-4803-ba6d-57ddfeba1305" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9e30bc8a-78a3-4f47-bc06-dc8f9f83b4f4" />

