### PR TITLE
test: execute TC-001 to TC-010 Sprint 2 CRUD test results

### DIFF
--- a/docs/test-logs/sprint2-test-cases.md
+++ b/docs/test-logs/sprint2-test-cases.md
@@ -1,7 +1,7 @@
 # Sprint 2 Test Cases: Course CRUD & Audit
 
 **Date:** April 9, 2026
-**Tester:** Angel Florendo
+**Tester:** Angel Florendo | Marlan Alfonso
 **Mandatory Sign-off:** TC-006 (Soft-Disable), TC-008 (Audit Trail)
 
 ---
@@ -12,37 +12,113 @@
 **Steps:**
 1. Go to /courses
 2. Click "Add Course"
-3. Fill in code, title, and description.
-4. Click Save.
-**Expected Result:** Course appears in table; Firestore doc has `isActive: true`.
-**Actual Result:** Course "CS101" appeared immediately; verified `isActive: true` in Firebase console.
+3. Fill in all required fields with valid data (Course Code: CS101, Title: Introduction to Computer Science, Units: 3, Year Level: Year 1, Semester: 1st)
+4. Click Save
+
+**Expected Result:** New course appears in the CourseListPage table. Document visible in Firestore console with isActive: true.
+**Actual Result:** Course "Introduction to Computer Science" (CS101) appeared in the table. Firestore document confirmed with isActive: true, correct fields, and createdAt timestamp.
 **Status:** PASS
 
-## TC-002: Add course with missing required fields
-**Status:** PASS (Form showed validation errors; Save button remained disabled)
+---
 
-## TC-003: Edit existing course details
-**Status:** PASS (Changes reflected in UI and Firestore immediately)
+## TC-002: Add course with a missing required field
 
-## TC-004: Prerequisite validation (Circular Reference)
-**Status:** PASS (System blocked adding a course as its own prerequisite)
+**Feature:** Add Course
+**Precondition:** App is running
 
-## TC-005: Prerequisite validation (Valid chain)
-**Status:** PASS (Prerequisites saved and displayed correctly)
-
-## TC-006: Soft-disable behavior (MANDATORY)
-**Feature:** Soft-Disable
-**Precondition:** Course exists and is currently active.
 **Steps:**
-1. Locate course in list.
-2. Click "Disable" icon.
-3. Confirm in `SoftDisableConfirmDialog`.
-**Expected Result:** Course remains in Firestore but `isActive` changes to `false`. UI shows "Inactive" badge.
-**Actual Result:** UI updated to "Inactive". Firestore document was NOT deleted; `isActive` field successfully toggled to `false`.
-**Status:** PASS ✅
+1. Go to /courses
+2. Click "Add Course"
+3. Leave Course Code blank, fill in all other fields
+4. Click Save
 
-## TC-007: Reactivate soft-disabled course
-**Status:** PASS (isActive toggled back to true; badge updated)
+**Expected Result:** Validation error shown, course NOT saved to Firestore.
+**Actual Result:** Browser native validation tooltip appeared: "Please fill out this field." Course was not submitted or saved to Firestore.
+**Status:** PASS
+
+---
+## TC-003: Edit an existing course
+
+**Feature:** Edit Course
+**Precondition:** At least one course exists in Firestore
+
+**Steps:**
+1. Go to /courses
+2. Click "Edit" on the CS101 (Introduction to Computer Science) course
+3. Change Course Title to "Introduction to Computer Science - Updated"
+4. Click "Update Course"
+
+**Expected Result:** Updated title appears in the CourseListPage table. Firestore document reflects the new courseTitle.
+**Actual Result:** Title updated to "Introduction to Computer Science - Updated" visible in the table. Firestore confirmed courseTitle: "Introduction to Computer Science - Updated" on the same document (isActive: true preserved).
+**Status:** PASS
+
+---
+
+## TC-004: Add a prerequisite to a course
+
+**Feature:** Edit Course / Prerequisites
+**Precondition:** A course with no prerequisites exists in Firestore
+
+**Steps:**
+1. Go to /courses
+2. Click "Edit" on CS402 (Intelligent Systems), which had no prerequisites
+3. Select "CS101 — Introduction to Programming" from the prerequisites list
+4. Click "Update Course"
+
+**Expected Result:** Prerequisites column for CS402 shows CS101 in the table. Firestore prerequisites array includes "CS101".
+**Actual Result:** CS402 (Intelligent Systems) now shows CS101 in the Prerequisites column. Firestore confirmed update.
+**Status:** PASS
+
+---
+
+## TC-005: Attempt to add a circular prerequisite
+
+**Feature:** Circular Dependency Validation
+**Precondition:** CS402 has CS101 as a prerequisite
+
+**Steps:**
+1. Go to /courses
+2. Click "Edit" on CS101 (Introduction to Programming)
+3. Select CS402 (Intelligent Systems) as a prerequisite — which already depends on CS101
+4. Click "Update Course"
+
+**Expected Result:** Circular dependency error shown, change NOT saved to Firestore.
+**Actual Result:** "Update Course" button became unclickable/disabled upon selecting CS402, preventing the circular dependency from being saved.
+**Status:** PASS
+
+---
+
+## TC-006: Soft-disable a course 🔒 MANDATORY SIGN-OFF
+
+**Feature:** Soft Disable
+**Precondition:** At least one active course exists
+
+**Steps:**
+1. Go to /courses
+2. Click "Disable" on CS402 (Intelligent Systems)
+3. Confirm in the dialog
+4. Check the table and Firestore console
+
+**Expected Result:** Course disappears from the table. Firestore document has isActive: false. Document still exists (not deleted).
+**Actual Result:** CS402 (Intelligent Systems) disappeared from the CourseListPage table. Firestore confirmed isActive: false on document BW3z6uoLCaKK1zwibbzN. Document still exists — not deleted.
+**Status:** PASS ✅ MANDATORY SIGN-OFF CLEARED
+
+---
+
+## TC-007: Verify disabled course is hidden from the list
+
+**Feature:** Course List Filtering by isActive
+**Precondition:** At least one course exists in Firestore
+
+**Steps:**
+1. In Firestore console, manually set isActive: false on an active course document
+2. Go to /courses and refresh the page
+
+**Expected Result:** The manually disabled course does NOT appear in the table.
+**Actual Result:** Course with isActive: false did not appear in the CourseListPage table after refresh.
+**Status:** PASS
+
+---
 
 ## TC-008: No-hard-delete audit (MANDATORY)
 **Feature:** Audit Security
@@ -54,21 +130,35 @@
 **Actual Result:** Confirmed no Delete option in `CourseListPage`. Grep search of `/src` returned 0 results for `deleteDoc` on course collections.
 **Status:** PASS ✅
 
-## TC-009: Course search/filter functionality
-**Status:** PASS (List filtered correctly by Course Code)
+---
 
-## TC-010: Firestore state persistence on refresh
-**Status:** PASS (Data remains consistent after browser refresh)
+## TC-009: Filter CourseListPage by year level
 
-TC #,Test Case Description,Actual Result,Status
-TC-001,Add course with all fields,"Created ""CS202: Data Structures"". Course appeared in table. Firestore doc verified with isActive: true.",✅ PASS
-TC-002,Missing courseCode,"System displayed ""Course Code is required"" below the input. Save button remained inactive. No Firestore write.",✅ PASS
-TC-003,Edit existing course,"Changed ""Intro to Programming"" to ""Advanced Programming"". Table and Firestore updated successfully.",✅ PASS
-TC-004,Add prerequisite,"Added ""CS101"" to ""CS201"". Firestore prerequisites array now contains [""CS101""].",✅ PASS
-TC-005,Circular prerequisite,"Attempted to link CS101 back to CS201. UI blocked the update with a ""Circular Dependency Detected"" warning.",✅ PASS
-TC-006,Soft-disable (MANDATORY),"Clicked Disable on CS101. Disappeared from UI. Checked Firestore: document still exists, isActive is now false.",✅ PASS 🔒
-TC-007,Verify hidden state,"Manually set ""MATH11"" to isActive: false in console. Refreshed page; MATH11 is no longer visible in list.",✅ PASS
-TC-008,No hard-delete audit,"Ran grep -r ""deleteDoc"" src/services/. Terminal returned zero results. No hard deletion code exists.",✅ PASS 🔒
-TC-009,Filter by year level,UI does not yet have a Year Level dropdown selector.,⚠️ DEFERRED
-TC-010,Duplicate courseCode,"Attempted to add another ""CS101"". System returned ""Course Code already exists"" error.",✅ PASS
+**Feature:** Year Level Filter
+**Precondition:** App is running with multiple courses of different year levels
 
+**Steps:**
+1. Go to /courses
+2. Look for a Year Level filter on the page
+
+**Expected Result:** If filter exists, only courses matching selected year level appear.
+**Actual Result:** No year level filter found on the CourseListPage.
+**Status:** DEFERRED — Feature not yet implemented, moved to Sprint 3
+
+---
+
+## TC-010: Add course with duplicate courseCode
+
+**Feature:** Duplicate Course Code Validation
+**Precondition:** CS101 already exists in Firestore
+
+**Steps:**
+1. Go to /courses
+2. Click "Add New Course"
+3. Enter CS101 as the Course Code (already exists)
+4. Fill in all other fields with valid data
+5. Click "Add Course"
+
+**Expected Result:** Duplicate code error shown, no second document created in Firestore.
+**Actual Result:** Course was saved successfully with duplicate code CS101 — no validation error shown, second document created in Firestore.
+**Status:** FAIL ❌ — GitHub Issue required


### PR DESCRIPTION
## Sprint 2 Test Execution Summary

All 10 Sprint 2 test cases have been documented and executed.

### Results
| Test | Description | Status |
|------|-------------|--------|
| TC-001 | Add course with all required fields | ✅ PASS |
| TC-002 | Add course with missing required field | ✅ PASS |
| TC-003 | Edit an existing course | ✅ PASS |
| TC-004 | Add a prerequisite to a course | ✅ PASS |
| TC-005 | Attempt circular prerequisite | ✅ PASS |
| TC-006 🔒 | Soft-disable a course | ✅ PASS |
| TC-007 | Disabled course hidden from list | ✅ PASS |
| TC-008 🔒 | No hard-delete audit | ✅ PASS |
| TC-009 | Filter by year level | ⏭️ DEFERRED to Sprint 3 |
| TC-010 | Duplicate courseCode validation | ❌ FAIL |

### Mandatory Sign-offs
- ✅ TC-006 PASS — Soft-disable confirmed working, document not deleted
- ✅ TC-008 PASS — No deleteDoc found in src/services/

### Issues Filed
- [BUG] TC-010: No duplicate courseCode validation on Add Course

### Notes
- TC-009 deferred — year level filter not yet implemented
- TC-008 run via PowerShell: `Get-ChildItem -Path src/services -Recurse | Select-String -Pattern "deleteDoc"`
