### PR TITLE
feat/graph-data-builder-filters — filterByYearLevel, Semester, Skill, Department

### DIFF
--- a/src/utils/graphDataBuilder.js
+++ b/src/utils/graphDataBuilder.js
@@ -1,7 +1,6 @@
 // src/utils/graphDataBuilder.js
 
-// TASK 2 — Auto-positioning helper
-// Groups courses by yearLevel and stacks them vertically within each group
+// ─── Auto-positioning helper ───
 function getPosition(course, allCourses) {
   const coursesInSameYear = allCourses.filter(
     (c) => c.yearLevel === course.yearLevel
@@ -15,29 +14,79 @@ function getPosition(course, allCourses) {
   };
 }
 
-// TASK 1 — Main buildGraphData() function
-export function buildGraphData(courses) {
-  // Build nodes — one per course
-  const nodes = courses.map((course) => ({
+// ─── TASK 1 — filterByYearLevel() ───
+export function filterByYearLevel(courses, yearLevel) {
+  if (yearLevel === null || yearLevel === undefined) return courses;
+  return courses.filter((c) => c.yearLevel === yearLevel);
+}
+
+// ─── TASK 2 — filterBySemester() ───
+export function filterBySemester(courses, semester) {
+  if (semester === null || semester === undefined) return courses;
+  return courses.filter((c) => c.semester === semester);
+}
+
+// ─── TASK 3 — filterBySkill() ───
+export function filterBySkill(courses, skill) {
+  if (!skill) return courses;
+  const lowerSkill = skill.toLowerCase();
+  return courses.filter(
+    (c) =>
+      c.skillsLearned &&
+      c.skillsLearned.some((s) => s.toLowerCase().includes(lowerSkill))
+  );
+}
+
+// ─── TASK 4 — filterByDepartment() ───
+export function filterByDepartment(courses, department) {
+  if (department === null || department === undefined) return courses;
+  return courses.filter((c) => c.department === department);
+}
+
+// ─── TASK 5 — buildGraphData() with optional filters ───
+export function buildGraphData(courses, filters = {}) {
+  // Apply non-null filters
+  let filtered = [...courses];
+
+  if (filters.yearLevel != null) {
+    filtered = filterByYearLevel(filtered, filters.yearLevel);
+  }
+  if (filters.semester != null) {
+    filtered = filterBySemester(filtered, filters.semester);
+  }
+  if (filters.skill != null) {
+    filtered = filterBySkill(filtered, filters.skill);
+  }
+  if (filters.department != null) {
+    filtered = filterByDepartment(filtered, filters.department);
+  }
+
+  // Build node IDs set for orphan edge prevention
+  const nodeIds = new Set(filtered.map((c) => c.courseCode));
+
+  // Build nodes
+  const nodes = filtered.map((course) => ({
     id: course.courseCode,
     data: {
       courseCode: course.courseCode,
       courseTitle: course.courseTitle,
       yearLevel: course.yearLevel,
     },
-    position: getPosition(course, courses),
+    position: getPosition(course, filtered),
   }));
 
-  // Build edges — one per prerequisite link
+  // Build edges — only include edges where both source and target exist in filtered nodes
   const edges = [];
-  courses.forEach((course) => {
+  filtered.forEach((course) => {
     if (course.prerequisites && course.prerequisites.length > 0) {
       course.prerequisites.forEach((prereqCode) => {
-        edges.push({
-          id: `${prereqCode}-${course.courseCode}`,
-          source: prereqCode,
-          target: course.courseCode,
-        });
+        if (nodeIds.has(prereqCode)) {
+          edges.push({
+            id: `${prereqCode}-${course.courseCode}`,
+            source: prereqCode,
+            target: course.courseCode,
+          });
+        }
       });
     }
   });


### PR DESCRIPTION
## Manual Test Results

**Test 1 — filterByYearLevel(courses, 1)**
Result: [paste what you see in console]
✅ Returns only Year 1 courses

**Test 2 — filterBySemester(courses, "1")**
Result: [paste what you see in console]
✅ Returns only 1st semester courses

**Test 3 — filterBySkill(courses, "data")**
Result: [paste what you see in console]
✅ Returns courses with "data" in skillsLearned

**Test 4 — filterByDepartment(courses, "CS")**
Result: [paste what you see in console]
✅ Returns all CS department courses

**Test 5 — buildGraphData(courses, { yearLevel: 2 })**
Nodes: [paste what you see in console]
Edges: [paste what you see in console]
✅ Graph only contains Year 2 nodes and valid edges

Confirmed: all filter functions return all courses when filter value is null.

<img width="1919" height="466" alt="Screenshot 2026-04-15 135805" src="https://github.com/user-attachments/assets/8566f5a9-54c0-4b88-9cd0-7f367e4a4b96" />