### PR TITLE
docs: add 4 Architecture Decision Records in /docs/adr/

### DIFF
--- a/docs/adr/adr-001-firebase-vs-supabase.md
+++ b/docs/adr/adr-001-firebase-vs-supabase.md
@@ -1,0 +1,38 @@
+# ADR-001: Firebase Firestore as Backend Database
+
+**Date:** 2026-03-27
+**Status:** Accepted
+**Decided by:** Marlan Alfonso -- Scrum Master + Knowledge Management Analyst
+
+## Context
+The project required a backend database and hosting solution with the following constraints:
+- No credit card required (must work on a free tier)
+- Real-time data capability for live curriculum map updates
+- Easy integration with a JavaScript/React frontend
+- Minimal backend infrastructure to manage
+
+A decision was needed between available BaaS (Backend-as-a-Service) platforms that could satisfy these requirements without incurring cost.
+
+## Decision
+**Firebase Firestore (Spark plan)** was selected as the backend database.
+
+## Alternatives Considered
+| Option | Reason Rejected |
+|--------|----------------|
+| Supabase (PostgreSQL-based) | Also has a free tier, but requires more relational schema design; document model in Firestore fits the nested course/prerequisite data structure more naturally |
+| PlanetScale | MySQL-compatible serverless DB, but requires separate hosting solution; no built-in real-time support |
+|Plain JSON files |No real-time capability, no multi-user support, not scalable beyond local dev |
+
+## Consequences
+
+**Positive:** 
+- Free hosting and database on a single platform (Spark plan) — no credit card required
+- Firestore's document model maps cleanly onto the course data structure (each course as a document with prerequisite references)
+- Official JavaScript SDK (firebase/firestore) is well-documented and integrates seamlessly with React
+- Real-time listeners (onSnapshot) enable live updates to the curriculum map without polling
+- Single firebase.json config covers both Firestore and Hosting
+
+**Negative / Trade-offs:** 
+- Cloud Functions are not available on the Spark plan — any server-side logic must be handled client-side or deferred to a paid tier
+- Firestore does not support full-text search natively; a third-party solution (e.g., Algolia) would be required for search features
+- Vendor lock-in to Google's Firebase ecosystem makes future migration more involved

--- a/docs/adr/adr-002-react-flow-vs-d3.md
+++ b/docs/adr/adr-002-react-flow-vs-d3.md
@@ -1,0 +1,40 @@
+# ADR-002: React Flow for Curriculum Graph Visualization
+
+**Date:** 2026-04-04
+**Status:** Accepted
+**Decided by:** Angela Militar -- UI/UX Designer
+
+## Context
+The curriculum map feature required an interactive graph visualization library capable of:
+
+- Rendering course nodes and prerequisite edges as a navigable graph
+- Supporting zoom, pan, and drag interactions
+- Allowing custom node and edge rendering (e.g., showing course status, credits, or color coding)
+- Integrating naturally within the existing React component tree
+
+A decision was needed on which graph/visualization library to adopt.
+
+## Decision
+**React Flow** was selected as the graph visualization library.
+
+## Alternatives Considered
+| Option | Reason Rejected |
+|--------|----------------|
+| D3.js | Extremely powerful, but operates directly on the DOM — requires imperative code that conflicts with React's declarative model; significant boilerplate for zoom/pan/drag behaviors |
+| Cytoscape.js | Feature-rich for graph theory use cases, but not React-native; integration requires a wrapper and manual lifecycle management |
+| Vis.js | Good built-in physics layouts, but similarly not React-native and has a heavier, older API surface |
+
+## Consequences
+
+**Positive:** 
+
+- React-native component model means nodes and edges are standard React components — no manual DOM manipulation or useEffect hacks to sync D3 with React state
+- Built-in zoom, pan, minimap, and controls are available out of the box with minimal configuration
+- Custom node types and edge types are straightforward to implement using React components, enabling rich course card UI within the graph
+- Active community and well-maintained documentation reduce onboarding time
+
+**Negative / Trade-offs:** 
+
+- Larger bundle size compared to a purpose-built, minimal D3 implementation
+- Physics-based or force-directed layouts (common in D3) require additional plugins or manual implementation in React Flow
+- Less flexibility for highly custom graph algorithms or rendering pipelines that D3 would expose directly

--- a/docs/adr/adr-003-firebase-hosting-vs-vercel.md
+++ b/docs/adr/adr-003-firebase-hosting-vs-vercel.md
@@ -1,0 +1,38 @@
+# ADR-003: Firebase Hosting for Static Site Deployment
+
+**Date:** 2026-03-27
+**Status:** Accepted
+**Decided by:** Marlan Alfonso -- Scrum Master + Knowledge Management Analyst
+
+## Context
+The Vite + React application needed a free static hosting solution for production deployment. Requirements:
+
+- Free tier with no credit card
+- Support for single-page application (SPA) routing (redirect all paths to index.html)
+- Compatible with the existing Firebase project setup
+- Minimal additional configuration overhead
+
+## Decision
+**Firebase Hosting** was selected as the deployment platform.
+
+## Alternatives Considered
+| Option | Reason Rejected |
+|--------|----------------|
+| Vercel | Excellent platform with superior CI/CD GitHub integration, but introduces a second platform account and separate configuration alongside the existing Firebase project |
+| Netlify |Similar to Vercel — strong CI/CD and preview deployments, but again adds a separate platform with its own config (```netlify.toml```) separate from ```firebase.json``` |
+| GitHub Pages | Free and tightly integrated with the repo, but requires workarounds for SPA client-side routing and does not support custom rewrites easily |
+
+## Consequences
+
+**Positive:** 
+
+- Everything lives on one platform — Firestore, Authentication (if added later), and Hosting are all managed under a single Firebase project and ```firebase.json```
+- No additional account or dashboard to manage
+- SPA rewrite rules (```"rewrites": [{ "source": "**", "destination": "/index.html" }]```) are simple to configure in ```firebase.json```
+- ```firebase deploy --only hosting``` gives a fast, predictable deploy command
+
+**Negative / Trade-offs:** 
+
+- Vercel offers automatic GitHub-triggered deployments and per-PR preview URLs out of the box — Firebase Hosting requires a manual ```firebase deploy``` or custom CI/CD pipeline setup to match this
+- Firebase Hosting's CDN and edge network is less globally distributed compared to Vercel's edge network
+- Build step (```vite build```) must be run locally or in CI before deploying; there is no built-in build integration like Vercel provides

--- a/docs/adr/adr-004-soft-disable-data-model.md
+++ b/docs/adr/adr-004-soft-disable-data-model.md
@@ -1,0 +1,33 @@
+# ADR-004: Soft-Disable Pattern for Course Removal
+
+**Date:** 2026-03-27
+**Status:** Accepted
+**Decided by:** Marlan Alfonso -- Scrum Master + Knowledge Management Analyst
+
+## Context
+The curriculum map allows courses to be removed from the active view. However, courses in Firestore are referenced by other course documents as prerequisites (via document ID). This creates a referential integrity problem:
+ 
+> If a course document is hard-deleted and another course still lists it as a prerequisite, that edge becomes a broken reference — the graph renders a dangling pointer with no resolvable node.
+ 
+A decision was needed on how to handle course removal in a way that preserves graph integrity.
+
+## Decision
+**Soft-disable via `isActive: false`** — course documents are never deleted using `deleteDoc()`. Instead, a boolean field `isActive` is set to `false` to hide the course from the active curriculum map while retaining the document in Firestore.
+ 
+## Alternatives Considered
+| Option | Reason Rejected |
+|--------|----------------|
+| Hard delete (`deleteDoc()`) | Destroys the document permanently — any course that references the deleted course as a prerequisite will have a broken edge with no recoverable data |
+| Archive to a separate Firestore collection | Preserves data but requires updating all prerequisite references in other documents to point to the new collection path; adds complexity with no clear benefit over `isActive` |
+| Versioning with timestamps | Useful for audit trails but overkill for this use case; adds schema complexity and complicates queries without solving the broken-reference problem more cleanly than soft-disable |
+ 
+## Consequences
+**Positive:**
+- Prerequisite link integrity is fully preserved — course documents remain in place, so edges in the graph always resolve to a valid document
+- UI filtering is simple: all active queries include `.where("isActive", "==", true)` to exclude disabled courses from the map
+- Disabled courses can be re-enabled at any time by toggling `isActive` back to `true` — no data recovery needed
+- Historical prerequisite chains remain queryable for reporting or debugging purposes
+**Negative / Trade-offs:**
+- Firestore storage grows monotonically over time as courses are disabled but never purged; a periodic cleanup job would require upgrading to the Blaze plan for Cloud Functions
+- Every collection query **must** include the `isActive: true` filter — forgetting this in a new query will silently surface disabled courses in the UI
+- Composite indexes may be needed in Firestore when combining `isActive` with other query fields (e.g., `department`, `semester`), adding minor configuration overhead

--- a/docs/adr/adr-template.md
+++ b/docs/adr/adr-template.md
@@ -1,0 +1,21 @@
+# ADR-00X: [Decision Title]
+
+**Date:** YYYY-MM-DD
+**Status:** Accepted
+**Decided by:** [team member(s)]
+
+## Context
+[What situation or problem required a decision to be made?]
+
+## Decision
+[What was decided?]
+
+## Alternatives Considered
+| Option | Reason Rejected |
+|--------|----------------|
+| [Alternative 1] | [Why not chosen] |
+| [Alternative 2] | [Why not chosen] |
+
+## Consequences
+**Positive:** [What becomes easier or better because of this decision]
+**Negative / Trade-offs:** [What becomes harder or is given up]


### PR DESCRIPTION
All 5 files are ready under docs/adr/. Here's a quick summary of what was created:
 
## Alternatives Considered
| File | Decison |
|--------|----------------|
| adr-template.md | Reusable blank template for future ADRs|
| adr-001-firebase-vs-supabase.md | Firebase Firestore chosen over Supabase, PlanetScale, and JSON files |
| adr-002-react-flow-vs-d3.md | React Flow chosen over D3.js, Cytoscape.js, and Vis.js |
| adr-003-firebase-hosting-vs-vercel.md | Firebase Hosting chosen over Vercel, Netlify, and GitHub Pages |
| adr-004-soft-disable-data-model.md | isActive: false soft-disable pattern chosen over hard delete or archiving|