### PR TITLE
feat: build User Page — add user management with role-based access

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,20 +1,14 @@
-// src/App.jsx — ADD the roadmap route (diff shown below)
-// ──────────────────────────────────────────────────────────────────────────────
-// CHANGES from original:
-//   1. Import RoadmapPage
-//   2. Add <Route path="/roadmap" ... /> inside the protected block
-// ──────────────────────────────────────────────────────────────────────────────
-
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
-import { AuthProvider } from "./context/AuthContext.jsx";
-import ProtectedRoute from "./components/ProtectedRoute.jsx";
-import AppShell from "./components/layout/AppShell";
-import LoginPage from "./pages/LoginPage";
-import HomePage from "./pages/HomePage";
-import CourseListPage from "./pages/CourseListPage";
-import CurriculumMapPage from "./pages/CurriculumMapPage";
-import AboutPage from "./pages/AboutPage";
-import RoadmapPage from "./pages/RoadmapPage";   // ← NEW
+import { AuthProvider }      from "./context/AuthContext.jsx";
+import ProtectedRoute        from "./components/ProtectedRoute.jsx";
+import AppShell              from "./components/layout/AppShell";
+import LoginPage             from "./pages/LoginPage";
+import HomePage              from "./pages/HomePage";
+import CourseListPage        from "./pages/CourseListPage";
+import CurriculumMapPage     from "./pages/CurriculumMapPage";
+import AboutPage             from "./pages/AboutPage";
+import RoadmapPage           from "./pages/RoadmapPage";
+import UserManagementPage    from "./pages/UserManagementPage";   // ← ADD
 
 function ProtectedLayout({ children }) {
   return (
@@ -29,20 +23,21 @@ export default function App() {
     <AuthProvider>
       <BrowserRouter>
         <Routes>
-          {/* Public */}
-          <Route path="/login" element={<LoginPage />} />
-
-          {/* Protected */}
-          <Route path="/" element={<Navigate to="/home" replace />} />
+          <Route path="/login"   element={<LoginPage />} />
+          <Route path="/"        element={<Navigate to="/home" replace />} />
           <Route path="/home"    element={<ProtectedLayout><HomePage /></ProtectedLayout>} />
           <Route path="/courses" element={<ProtectedLayout><CourseListPage /></ProtectedLayout>} />
           <Route path="/map"     element={<ProtectedLayout><CurriculumMapPage /></ProtectedLayout>} />
+          <Route path="/roadmap" element={<ProtectedLayout><RoadmapPage /></ProtectedLayout>} />
           <Route path="/about"   element={<ProtectedLayout><AboutPage /></ProtectedLayout>} />
 
-          {/* ─── NEW ─────────────────────────────────────────────────────── */}
-          <Route path="/roadmap" element={<ProtectedLayout><RoadmapPage /></ProtectedLayout>} />
+          {/* Admin only */}
+          <Route path="/users" element={
+            <ProtectedRoute adminOnly>
+              <AppShell><UserManagementPage /></AppShell>
+            </ProtectedRoute>
+          } />
 
-          {/* Catch-all */}
           <Route path="*" element={<Navigate to="/home" replace />} />
         </Routes>
       </BrowserRouter>

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -2,9 +2,6 @@
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../context/useAuth";
 
-// Usage:
-//   <ProtectedRoute>            → any logged-in user
-//   <ProtectedRoute adminOnly>  → admins only
 export default function ProtectedRoute({ children, adminOnly = false }) {
   const { user, role, authLoading } = useAuth();
 
@@ -18,7 +15,8 @@ export default function ProtectedRoute({ children, adminOnly = false }) {
 
   if (!user) return <Navigate to="/login" replace />;
 
-  if (adminOnly && role !== "admin") {
+  // Allow both 'admin' and 'superadmin' to access admin routes
+  if (adminOnly && role !== "admin" && role !== "superadmin") {
     return <Navigate to="/courses" replace />;
   }
 

--- a/src/components/SoftDisableConfirmDialog.jsx
+++ b/src/components/SoftDisableConfirmDialog.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
 import { disableCourse } from '../services/courseService';
 
 export default function SoftDisableConfirmDialog({
@@ -32,53 +33,173 @@ export default function SoftDisableConfirmDialog({
 
   if (!isOpen) return null;
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+  return createPortal(
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 9999,
+        background: 'rgba(0, 0, 0, 0.5)',
+        backdropFilter: 'blur(2px)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '16px',
+        fontFamily: "'DM Sans', system-ui, sans-serif",
+      }}
+      onClick={handleCancel}
+    >
       <div
-        className="bg-white rounded-xl shadow-xl w-full max-w-md p-6"
-        onClick={e => e.stopPropagation()}
+        style={{
+          background: 'white',
+          borderRadius: '20px',
+          width: '100%',
+          maxWidth: '420px',
+          boxShadow: '0 25px 50px -12px rgba(0,0,0,0.25)',
+          overflow: 'hidden',
+          animation: 'modalSlideIn 0.2s cubic-bezier(0.34,1.2,0.64,1)',
+        }}
+        onClick={(e) => e.stopPropagation()}
       >
-        {/* Warning Icon & Title */}
-        <div className="flex items-center gap-3 mb-4">
-          <span className="text-3xl">⚠️</span>
-          <h3 className="text-xl font-bold text-gray-800">Disable Course?</h3>
+        <div
+          style={{
+            padding: '20px 24px 12px',
+            borderBottom: '1px solid #f1f5f9',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+          }}
+        >
+          <div
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: 12,
+              background: '#fee2e2',
+              color: '#dc2626',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M10 11v5M14 11v5" />
+              <path d="M5 6v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V6" />
+            </svg>
+          </div>
+          <div style={{ flex: 1 }}>
+            <h3 style={{ margin: 0, fontSize: 18, fontWeight: 700, color: '#0f172a' }}>
+              Archive Course
+            </h3>
+            <p style={{ margin: '4px 0 0', fontSize: 13, color: '#475569' }}>
+              This action can be undone later.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              background: 'none',
+              border: 'none',
+              color: '#94a3b8',
+              fontSize: 24,
+              cursor: 'pointer',
+              padding: 4,
+              lineHeight: 1,
+              borderRadius: 8,
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = '#f1f5f9')}
+            onMouseLeave={(e) => (e.currentTarget.style.background = 'none')}
+          >
+            ×
+          </button>
         </div>
 
-        {/* Message */}
-        <p className="text-gray-600 text-sm mb-2">
-          Are you sure you want to disable{' '}
-          <span className="font-semibold text-gray-900">{courseCode}</span>{' '}
-          from the curriculum map?
-        </p>
-        <p className="text-gray-400 text-xs mb-5">
-          This action can be undone by an administrator.
-        </p>
+        <div style={{ padding: '20px 24px' }}>
+          <p style={{ margin: 0, fontSize: 14, lineHeight: 1.6, color: '#334155' }}>
+            Are you sure you want to archive <strong>{courseCode}</strong>? 
+            The course will be moved to the archived section and will not appear in the active curriculum map.
+          </p>
+          <p style={{ margin: '12px 0 0', fontSize: 12, color: '#dc2626', fontWeight: 500 }}>
+            You can restore it later from the Archived tab.
+          </p>
+          {error && (
+            <div style={{
+              marginTop: 16,
+              padding: '10px 14px',
+              borderRadius: 10,
+              background: '#fef2f2',
+              border: '1px solid #fecaca',
+              color: '#b91c1c',
+              fontSize: 13,
+            }}>
+              {error}
+            </div>
+          )}
+        </div>
 
-        {/* Error */}
-        {error && (
-          <div className="bg-red-50 border border-red-300 text-red-700 text-sm px-4 py-3 rounded-lg mb-4">
-            {error}
-          </div>
-        )}
-
-        {/* Action Buttons */}
-        <div className="flex gap-3">
+        <div style={{ padding: '16px 24px 24px', display: 'flex', gap: 12, justifyContent: 'flex-end' }}>
           <button
             onClick={handleCancel}
             disabled={loading}
-            className="flex-1 px-4 py-2.5 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition duration-150 min-h-[44px] disabled:opacity-60"
+            style={{
+              padding: '8px 20px',
+              borderRadius: 10,
+              border: '1px solid #cbd5e1',
+              background: 'transparent',
+              color: '#475569',
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: 'pointer',
+              transition: 'all 0.15s',
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = '#f1f5f9')}
+            onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
           >
             Cancel
           </button>
           <button
             onClick={handleConfirmDisable}
             disabled={loading}
-            className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg transition duration-150 min-h-[44px] disabled:opacity-60"
+            style={{
+              padding: '8px 20px',
+              borderRadius: 10,
+              border: 'none',
+              background: '#dc2626',
+              color: '#fff',
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: 'pointer',
+              opacity: loading ? 0.7 : 1,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              transition: 'transform 0.1s',
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.transform = 'translateY(-1px)')}
+            onMouseLeave={(e) => (e.currentTarget.style.transform = 'none')}
           >
-            {loading ? 'Disabling...' : 'Confirm Disable'}
+            {loading && (
+              <span style={{
+                width: 14,
+                height: 14,
+                border: '2px solid rgba(255,255,255,0.3)',
+                borderTopColor: '#fff',
+                borderRadius: '50%',
+                display: 'inline-block',
+                animation: 'spin 0.7s linear infinite',
+              }} />
+            )}
+            {loading ? 'Archiving...' : 'Archive Course'}
           </button>
         </div>
       </div>
-    </div>
+      <style>{`
+        @keyframes modalSlideIn {
+          from { opacity: 0; transform: scale(0.95); }
+          to { opacity: 1; transform: scale(1); }
+        }
+      `}</style>
+    </div>,
+    document.body
   );
 }

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -44,6 +44,14 @@ const NAV_ICONS = {
       <circle cx="8" cy="5" r="0.8" fill="currentColor"/>
     </svg>
   ),
+  "/users": (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <circle cx="6" cy="5" r="2.5" stroke="currentColor" strokeWidth="1.4"/>
+    <path d="M2 13c0-2.8 1.8-4 4-4s4 1.2 4 4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+    <path d="M11 7.5c1.5 0 2.5.8 2.5 2.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+    <circle cx="11" cy="5" r="1.5" stroke="currentColor" strokeWidth="1.3"/>
+  </svg>
+  ),
 };
 
 export default function AppShell({ children }) {
@@ -69,15 +77,17 @@ export default function AppShell({ children }) {
     document.documentElement.setAttribute("data-theme", dark ? "dark" : "light");
   }, [dark]);
 
+    const isAdmin = role === "admin";
+
   const navLinks = [
     { to: "/home",    label: "Dashboard" },
     { to: "/courses", label: "Courses" },
     { to: "/map",     label: "Curriculum Map" },
     { to: "/roadmap", label: "Roadmap" },
+    ...(isAdmin ? [{ to: "/users", label: "Student" }] : []),  // ← ADD
     { to: "/about",   label: "About" },
   ];
 
-  const isAdmin = role === "admin";
 
   return (
     <DarkModeContext.Provider value={{ dark, toggle: () => setDark(d => !d) }}>
@@ -304,11 +314,11 @@ export default function AppShell({ children }) {
               )}
               <div className="min-w-0 flex-1">
                 <p className="user-name text-[13px] font-semibold truncate leading-tight">
-                  {user?.displayName ?? "User"}
+                  {user?.displayName ?? "Student"}
                 </p>
                 <div className="mt-1">
                   <span className={isAdmin ? "role-badge-admin" : "role-badge-user"}>
-                    {isAdmin ? "Admin" : "User"}
+                    {isAdmin ? "Admin" : "Student"}
                   </span>
                 </div>
               </div>
@@ -389,7 +399,7 @@ export default function AppShell({ children }) {
             <div>
               <p className="text-sm font-semibold text-white">{user?.displayName ?? "User"}</p>
               <span className={isAdmin ? "role-badge-admin" : "role-badge-user"}>
-                {isAdmin ? "Admin" : "User"}
+                {isAdmin ? "Admin" : "Student"}
               </span>
             </div>
             <button onClick={logout} className="text-xs text-red-300 font-semibold hover:text-red-200 transition">

--- a/src/components/layout/AppShell.jsx
+++ b/src/components/layout/AppShell.jsx
@@ -45,12 +45,12 @@ const NAV_ICONS = {
     </svg>
   ),
   "/users": (
-  <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-    <circle cx="6" cy="5" r="2.5" stroke="currentColor" strokeWidth="1.4"/>
-    <path d="M2 13c0-2.8 1.8-4 4-4s4 1.2 4 4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
-    <path d="M11 7.5c1.5 0 2.5.8 2.5 2.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
-    <circle cx="11" cy="5" r="1.5" stroke="currentColor" strokeWidth="1.3"/>
-  </svg>
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <circle cx="6" cy="5" r="2.5" stroke="currentColor" strokeWidth="1.4"/>
+      <path d="M2 13c0-2.8 1.8-4 4-4s4 1.2 4 4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+      <path d="M11 7.5c1.5 0 2.5.8 2.5 2.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+      <circle cx="11" cy="5" r="1.5" stroke="currentColor" strokeWidth="1.3"/>
+    </svg>
   ),
 };
 
@@ -77,27 +77,34 @@ export default function AppShell({ children }) {
     document.documentElement.setAttribute("data-theme", dark ? "dark" : "light");
   }, [dark]);
 
-    const isAdmin = role === "admin";
+  // Allow both admin and superadmin to see the Users page
+  const isAdminOrSuper = role === "admin" || role === "superadmin";
+
+  // Determine badge text and style
+  const getRoleBadge = () => {
+    if (role === "superadmin") return { text: "Superadmin", class: "role-badge-admin" };
+    if (role === "admin") return { text: "Admin", class: "role-badge-admin" };
+    return { text: "Student", class: "role-badge-user" };
+  };
+
+  const roleBadge = getRoleBadge();
 
   const navLinks = [
     { to: "/home",    label: "Dashboard" },
     { to: "/courses", label: "Courses" },
     { to: "/map",     label: "Curriculum Map" },
     { to: "/roadmap", label: "Roadmap" },
-    ...(isAdmin ? [{ to: "/users", label: "Student" }] : []),  // ← ADD
+    ...(isAdminOrSuper ? [{ to: "/users", label: "Users" }] : []),
     { to: "/about",   label: "About" },
   ];
 
-
   return (
     <DarkModeContext.Provider value={{ dark, toggle: () => setDark(d => !d) }}>
-      {/* CHANGED: added overflow-x-hidden to the outermost wrapper */}
       <div className={`min-h-screen flex overflow-x-hidden ${dark ? "bg-gray-950" : "bg-gray-50"}`}>
         <style>{`
           @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap');
           * { font-family: 'DM Sans', system-ui, sans-serif; }
 
-          /* CHANGED: prevent html/body from ever growing a horizontal scrollbar */
           html, body, #root {
             overflow-x: hidden;
             max-width: 100vw;
@@ -255,7 +262,6 @@ export default function AppShell({ children }) {
 
         {/* ── Sidebar — desktop only ─────────────────────────────────── */}
         <aside className="sidebar hidden md:flex flex-col w-56 min-h-screen flex-shrink-0 sidebar-enter fixed top-0 left-0 bottom-0 z-20">
-
           <div className="sidebar-brand px-5 py-4">
             <p className="brand-title font-bold text-sm tracking-wide">SCM</p>
             <p className="brand-sub text-[11px] mt-0.5">Knowledge Map</p>
@@ -317,8 +323,8 @@ export default function AppShell({ children }) {
                   {user?.displayName ?? "Student"}
                 </p>
                 <div className="mt-1">
-                  <span className={isAdmin ? "role-badge-admin" : "role-badge-user"}>
-                    {isAdmin ? "Admin" : "Student"}
+                  <span className={roleBadge.class}>
+                    {roleBadge.text}
                   </span>
                 </div>
               </div>
@@ -398,8 +404,8 @@ export default function AppShell({ children }) {
           <div className="flex items-center justify-between py-3">
             <div>
               <p className="text-sm font-semibold text-white">{user?.displayName ?? "User"}</p>
-              <span className={isAdmin ? "role-badge-admin" : "role-badge-user"}>
-                {isAdmin ? "Admin" : "Student"}
+              <span className={roleBadge.class}>
+                {roleBadge.text}
               </span>
             </div>
             <button onClick={logout} className="text-xs text-red-300 font-semibold hover:text-red-200 transition">
@@ -409,16 +415,11 @@ export default function AppShell({ children }) {
         </div>
 
         {/* ── Main content ─────────────────────────────────────────── */}
-        {/* CHANGED: removed overflow-auto from <main> — it was creating its own
-            scroll context and bypassing the overflow-x:hidden on the wrapper.
-            overflow-hidden on the wrapper + per-row scroll in CurriculumMapPage
-            handles everything correctly now. */}
         <div className="main-content flex-1 md:ml-56 pt-[52px] md:pt-0 min-h-screen overflow-x-hidden">
           <main key={location.pathname} className="flex-1 page-enter">
             {children}
           </main>
         </div>
-
       </div>
     </DarkModeContext.Provider>
   );

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -109,7 +109,6 @@ export function AuthProvider({ children }) {
     const userRole = await upsertUser(firebaseUser);
     setUser(firebaseUser);
     setRole(userRole);
-    console.log("✅ User signed in:", lowerEmail, "Role:", userRole);
   };
 
   const logout = async () => {
@@ -140,7 +139,6 @@ export function AuthProvider({ children }) {
 
     // Listen for auth state changes (for page refresh)
     const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
-      console.log("onAuthStateChanged triggered, user:", firebaseUser?.email);
       if (!isMounted) return;
       try {
         await handleUserAfterAuth(firebaseUser);

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,19 +1,16 @@
 // src/context/AuthContext.jsx
 import { useEffect, useState } from "react";
-import {
-  signInWithPopup,
-  signOut,
-  onAuthStateChanged,
-} from "firebase/auth";
+import { signInWithPopup, signOut, onAuthStateChanged } from "firebase/auth";
 import { doc, getDoc } from "firebase/firestore";
 import { auth, googleProvider, db } from "../lib/firebaseClient";
 import { AuthContext } from "./authContext";
+import { upsertUser } from "../services/userService";   // ← ADD
 
 export function AuthProvider({ children }) {
-  const [user, setUser] = useState(null);
-  const [role, setRole] = useState(null);
+  const [user,        setUser]        = useState(null);
+  const [role,        setRole]        = useState(null);
   const [authLoading, setAuthLoading] = useState(true);
-  const [authError, setAuthError] = useState(null);
+  const [authError,   setAuthError]   = useState(null);
 
   const isNEUEmail = (email) => email?.endsWith("@neu.edu.ph");
 
@@ -30,7 +27,7 @@ export function AuthProvider({ children }) {
     setAuthError(null);
     try {
       const result = await signInWithPopup(auth, googleProvider);
-      const email = result.user.email;
+      const email  = result.user.email;
 
       if (!isNEUEmail(email)) {
         await signOut(auth);
@@ -39,6 +36,7 @@ export function AuthProvider({ children }) {
       }
 
       const userRole = await fetchRole(email);
+      await upsertUser(result.user);   // ← ADD: save/update user doc
       setRole(userRole);
       setUser(result.user);
     } catch (err) {
@@ -58,13 +56,13 @@ export function AuthProvider({ children }) {
     const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
       if (firebaseUser) {
         const email = firebaseUser.email;
-
         if (!isNEUEmail(email)) {
           await signOut(auth);
           setUser(null);
           setRole(null);
         } else {
           const userRole = await fetchRole(email);
+          await upsertUser(firebaseUser);   // ← ADD: refresh on reload
           setUser(firebaseUser);
           setRole(userRole);
         }
@@ -74,7 +72,6 @@ export function AuthProvider({ children }) {
       }
       setAuthLoading(false);
     });
-
     return () => unsubscribe();
   }, []);
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,49 +1,115 @@
 // src/context/AuthContext.jsx
 import { useEffect, useState } from "react";
-import { signInWithPopup, signOut, onAuthStateChanged } from "firebase/auth";
-import { doc, getDoc } from "firebase/firestore";
+import {
+  signInWithPopup,
+  signInWithRedirect,
+  getRedirectResult,
+  signOut,
+  onAuthStateChanged,
+} from "firebase/auth";
+import { doc, getDoc, setDoc } from "firebase/firestore";
 import { auth, googleProvider, db } from "../lib/firebaseClient";
 import { AuthContext } from "./authContext";
-import { upsertUser } from "../services/userService";   // ← ADD
 
 export function AuthProvider({ children }) {
-  const [user,        setUser]        = useState(null);
-  const [role,        setRole]        = useState(null);
+  const [user, setUser] = useState(null);
+  const [role, setRole] = useState(null);
   const [authLoading, setAuthLoading] = useState(true);
-  const [authError,   setAuthError]   = useState(null);
+  const [authError, setAuthError] = useState(null);
 
   const isNEUEmail = (email) => email?.endsWith("@neu.edu.ph");
 
-  const fetchRole = async (email) => {
+  // Helper: upsert user document
+  const upsertUser = async (firebaseUser) => {
+    const email = firebaseUser.email.toLowerCase();
+    const userRef = doc(db, "users", email);
+    const profileData = {
+      displayName: firebaseUser.displayName || "",
+      photoURL: firebaseUser.photoURL || "",
+      uid: firebaseUser.uid,
+      lastLogin: new Date(),
+    };
+
     try {
-      const adminDoc = await getDoc(doc(db, "admins", email));
-      return adminDoc.exists() ? "admin" : "user";
-    } catch {
+      const userSnap = await getDoc(userRef);
+      if (!userSnap.exists()) {
+        await setDoc(userRef, {
+          email,
+          role: "user",
+          isBlocked: false,
+          createdAt: new Date(),
+          ...profileData,
+        });
+        return "user";
+      } else {
+        // Update profile, keep existing role
+        await setDoc(userRef, profileData, { merge: true });
+        return userSnap.data().role || "user";
+      }
+    } catch (err) {
+      console.error("Firestore upsert error:", err);
       return "user";
     }
   };
 
+  // Core sign-in function: try popup first, fallback to redirect
   const signInWithGoogle = async () => {
     setAuthError(null);
     try {
       const result = await signInWithPopup(auth, googleProvider);
-      const email  = result.user.email;
-
-      if (!isNEUEmail(email)) {
-        await signOut(auth);
-        setAuthError("Only @neu.edu.ph accounts are allowed.");
-        return;
-      }
-
-      const userRole = await fetchRole(email);
-      await upsertUser(result.user);   // ← ADD: save/update user doc
-      setRole(userRole);
-      setUser(result.user);
+      await handleUserAfterAuth(result.user);
     } catch (err) {
-      if (err.code !== "auth/popup-closed-by-user") {
-        setAuthError("Sign-in failed. Please try again.");
+      console.error("Popup sign-in error:", err);
+      // If popup fails (e.g., blocked), fallback to redirect
+      if (err.code === "auth/popup-blocked" || err.code === "auth/cancelled-popup-request") {
+        try {
+          await signInWithRedirect(auth, googleProvider);
+        } catch (redirectErr) {
+          setAuthError("Redirect sign-in failed. Please check your browser settings.");
+        }
+      } else {
+        setAuthError("Sign-in failed: " + err.message);
       }
     }
+  };
+
+  // Process user after authentication
+  const handleUserAfterAuth = async (firebaseUser) => {
+    if (!firebaseUser) {
+      setUser(null);
+      setRole(null);
+      return;
+    }
+
+    const email = firebaseUser.email;
+    if (!isNEUEmail(email)) {
+      await signOut(auth);
+      setAuthError("Only @neu.edu.ph accounts are allowed.");
+      setUser(null);
+      setRole(null);
+      return;
+    }
+
+    // Check if blocked
+    const lowerEmail = email.toLowerCase();
+    try {
+      const userDoc = await getDoc(doc(db, "users", lowerEmail));
+      if (userDoc.exists() && userDoc.data().isBlocked === true) {
+        await signOut(auth);
+        setAuthError("Your account has been blocked. Contact an administrator.");
+        setUser(null);
+        setRole(null);
+        return;
+      }
+    } catch (err) {
+      console.error("Block check error:", err);
+    }
+
+    // Create/update user doc and get role
+    const userRole = await upsertUser(firebaseUser);
+    setUser(firebaseUser);
+    setRole(userRole);
+    console.log("✅ User signed in:", lowerEmail, "Role:", userRole);
   };
 
   const logout = async () => {
@@ -52,28 +118,44 @@ export function AuthProvider({ children }) {
     setRole(null);
   };
 
+  // Effect to handle redirect result (if the user was redirected from Google)
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
-      if (firebaseUser) {
-        const email = firebaseUser.email;
-        if (!isNEUEmail(email)) {
-          await signOut(auth);
-          setUser(null);
-          setRole(null);
-        } else {
-          const userRole = await fetchRole(email);
-          await upsertUser(firebaseUser);   // ← ADD: refresh on reload
-          setUser(firebaseUser);
-          setRole(userRole);
+    let isMounted = true;
+
+    const handleRedirect = async () => {
+      try {
+        const result = await getRedirectResult(auth);
+        if (result && isMounted) {
+          await handleUserAfterAuth(result.user);
         }
-      } else {
-        setUser(null);
-        setRole(null);
+      } catch (err) {
+        console.error("Redirect result error:", err);
+        if (isMounted) setAuthError("Sign-in failed after redirect.");
+      } finally {
+        if (isMounted) setAuthLoading(false);
       }
-      setAuthLoading(false);
+    };
+
+    handleRedirect();
+
+    // Listen for auth state changes (for page refresh)
+    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
+      console.log("onAuthStateChanged triggered, user:", firebaseUser?.email);
+      if (!isMounted) return;
+      try {
+        await handleUserAfterAuth(firebaseUser);
+      } catch (err) {
+        console.error("onAuthStateChanged error:", err);
+      } finally {
+        if (isMounted) setAuthLoading(false);
+      }
     });
-    return () => unsubscribe();
-  }, []);
+
+    return () => {
+      isMounted = false;
+      unsubscribe();
+    };
+  }, []); // empty dependency array – runs once on mount
 
   return (
     <AuthContext.Provider

--- a/src/pages/CourseListPage.jsx
+++ b/src/pages/CourseListPage.jsx
@@ -1,3 +1,9 @@
+// src/pages/CourseListPage.jsx
+// CHANGES:
+// - Only superadmins see the Archive button. Admins can Restore (from disabled tab) but not Archive.
+// - Disabled tab is hidden for regular users (visible only to admins and superadmins).
+// - All other functionality unchanged.
+
 import React, { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import AddCourseModal from '../components/AddCourseModal';
@@ -14,7 +20,6 @@ const yearColors = {
   4: { bg: '#ede9fe', text: '#6d28d9', dot: '#a78bfa', darkBg: '#1e1040', darkText: '#c4b5fd' },
 };
 
-// ── Tooltip wrapper ────────────────────────────────────────────────────────
 function Tooltip({ text, children }) {
   const [show, setShow] = useState(false);
   return (
@@ -41,7 +46,6 @@ function Tooltip({ text, children }) {
   );
 }
 
-// ── Dropdown filter ────────────────────────────────────────────────────────
 function FilterDropdown({ label, value, options, onChange, dark }) {
   const [open, setOpen] = useState(false);
   const ref = useRef(null);
@@ -65,7 +69,6 @@ function FilterDropdown({ label, value, options, onChange, dark }) {
         color: isActive ? (dark ? '#93c5fd' : '#1d4ed8') : (dark ? '#d1d5db' : '#374151'),
         fontSize: 13, fontWeight: 600, fontFamily: 'inherit', cursor: 'pointer',
         whiteSpace: 'nowrap', transition: 'all 0.15s',
-        boxShadow: open ? '0 0 0 3px rgba(147,197,253,0.15)' : 'none',
       }}>
         <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: '.07em', textTransform: 'uppercase', color: isActive ? '#93c5fd' : (dark ? '#6b7280' : '#9ca3af') }}>
           {label}
@@ -112,9 +115,7 @@ function FilterDropdown({ label, value, options, onChange, dark }) {
   );
 }
 
-// ── Knowledge Details Drawer ───────────────────────────────────────────────
 function KnowledgeDrawer({ course, onClose, dark }) {
-  // Close on Escape key
   useEffect(() => {
     const handler = (e) => { if (e.key === 'Escape') onClose(); };
     document.addEventListener('keydown', handler);
@@ -131,13 +132,10 @@ function KnowledgeDrawer({ course, onClose, dark }) {
 
   return createPortal(
     <>
-      {/* Backdrop */}
       <div onClick={onClose} style={{
         position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.35)',
         zIndex: 9998, animation: 'fadeIn 0.2s ease',
       }} />
-
-      {/* Drawer */}
       <div style={{
         position: 'fixed', top: 0, right: 0, height: '100vh', width: 360,
         background: dark ? '#111827' : '#fff',
@@ -147,8 +145,6 @@ function KnowledgeDrawer({ course, onClose, dark }) {
         animation: 'drawerIn 0.25s cubic-bezier(0.34,1.56,0.64,1)',
         fontFamily: "'DM Sans', system-ui, sans-serif",
       }}>
-
-        {/* Header */}
         <div style={{
           padding: '16px 20px', borderBottom: `1px solid ${dark ? '#1f2937' : '#e5e7eb'}`,
           flexShrink: 0, display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between',
@@ -183,10 +179,7 @@ function KnowledgeDrawer({ course, onClose, dark }) {
           </button>
         </div>
 
-        {/* Body */}
         <div style={{ flex: 1, overflowY: 'auto', padding: 20, display: 'flex', flexDirection: 'column', gap: 16 }}>
-
-          {/* Info grid */}
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
             {[
               { label: 'Units', value: course.units },
@@ -204,11 +197,8 @@ function KnowledgeDrawer({ course, onClose, dark }) {
             ))}
           </div>
 
-          {/* Prerequisites */}
           <div>
-            <p style={{ margin: '0 0 8px', fontSize: 10, fontWeight: 700, color: '#6b7280', textTransform: 'uppercase', letterSpacing: '.07em' }}>
-              Prerequisites
-            </p>
+            <p style={{ margin: '0 0 8px', fontSize: 10, fontWeight: 700, color: '#6b7280', textTransform: 'uppercase', letterSpacing: '.07em' }}>Prerequisites</p>
             {course.prerequisites?.length > 0 ? (
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
                 {course.prerequisites.map(p => (
@@ -227,22 +217,8 @@ function KnowledgeDrawer({ course, onClose, dark }) {
             )}
           </div>
 
-          {/* Skills Learned */}
-          <div style={{
-            background: dark ? '#0a2e1a' : '#f0fdf4',
-            border: `1px solid ${dark ? '#166534' : '#bbf7d0'}`,
-            borderRadius: 10, padding: '12px 14px',
-          }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 10 }}>
-              <div style={{ width: 18, height: 18, borderRadius: 5, background: dark ? '#14532d' : '#dcfce7', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                <svg width="10" height="10" viewBox="0 0 12 12" fill="none">
-                  <path d="M2 6l3 3 5-5" stroke="#15803d" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                </svg>
-              </div>
-              <p style={{ fontSize: 10, fontWeight: 700, letterSpacing: '.07em', textTransform: 'uppercase', color: dark ? '#4ade80' : '#15803d', margin: 0 }}>
-                Skills Learned
-              </p>
-            </div>
+          <div style={{ background: dark ? '#0a2e1a' : '#f0fdf4', border: `1px solid ${dark ? '#166534' : '#bbf7d0'}`, borderRadius: 10, padding: '12px 14px' }}>
+            <p style={{ fontSize: 10, fontWeight: 700, letterSpacing: '.07em', textTransform: 'uppercase', color: dark ? '#4ade80' : '#15803d', margin: '0 0 8px' }}>Skills Learned</p>
             {skills.length > 0 ? (
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
                 {skills.map((skill, i) => (
@@ -260,22 +236,8 @@ function KnowledgeDrawer({ course, onClose, dark }) {
             )}
           </div>
 
-          {/* Knowledge Built */}
-          <div style={{
-            background: dark ? '#0c1e3d' : '#eff6ff',
-            border: `1px solid ${dark ? '#1e40af' : '#bfdbfe'}`,
-            borderRadius: 10, padding: '12px 14px',
-          }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 10 }}>
-              <div style={{ width: 18, height: 18, borderRadius: 5, background: dark ? '#1e3a5f' : '#dbeafe', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                <svg width="10" height="10" viewBox="0 0 12 12" fill="none">
-                  <path d="M6 2v8M2 6h8" stroke="#1d4ed8" strokeWidth="1.5" strokeLinecap="round"/>
-                </svg>
-              </div>
-              <p style={{ fontSize: 10, fontWeight: 700, letterSpacing: '.07em', textTransform: 'uppercase', color: dark ? '#93c5fd' : '#1d4ed8', margin: 0 }}>
-                Knowledge Built
-              </p>
-            </div>
+          <div style={{ background: dark ? '#0c1e3d' : '#eff6ff', border: `1px solid ${dark ? '#1e40af' : '#bfdbfe'}`, borderRadius: 10, padding: '12px 14px' }}>
+            <p style={{ fontSize: 10, fontWeight: 700, letterSpacing: '.07em', textTransform: 'uppercase', color: dark ? '#93c5fd' : '#1d4ed8', margin: '0 0 8px' }}>Knowledge Built</p>
             {course.knowledgeBuilt ? (
               <p style={{ fontSize: 12, color: dark ? '#bfdbfe' : '#1e40af', lineHeight: 1.65, margin: 0 }}>
                 {Array.isArray(course.knowledgeBuilt) ? course.knowledgeBuilt.join(', ') : course.knowledgeBuilt}
@@ -291,16 +253,22 @@ function KnowledgeDrawer({ course, onClose, dark }) {
   );
 }
 
-// ── Main page ──────────────────────────────────────────────────────────────
 export default function CourseListPage() {
   const { role } = useAuth();
-  const isAdmin = role === 'admin';
+
+  // ── ROLE CHECKS ──────────────────────────────────────────────────────────
+  const isSuperAdmin = role === 'superadmin';
+  const isAdmin      = role === 'admin';
+  const canWrite     = isSuperAdmin || isAdmin;           // add/edit/detail
+  const canArchive   = isSuperAdmin;                      // only superadmin can archive
+  const canRestore   = isSuperAdmin || isAdmin;           // admin & superadmin can restore
+  const canSeeDisabledTab = isSuperAdmin || isAdmin;      // regular users should NOT see archived tab
 
   const [courses, setCourses] = useState([]);
   const [disabledCourses, setDisabledCourses] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [activeTab, setActiveTab] = useState('active'); // 'active' | 'disabled'
+  const [activeTab, setActiveTab] = useState('active');
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [editingCourse, setEditingCourse] = useState(null);
   const [disablingCourse, setDisablingCourse] = useState(null);
@@ -312,7 +280,6 @@ export default function CourseListPage() {
   const [sortBy, setSortBy] = useState('default');
   const [visible, setVisible] = useState(false);
 
-  // Detect dark mode from parent app shell
   const [dark, setDark] = useState(() => document.documentElement.classList.contains('dark'));
   useEffect(() => {
     const obs = new MutationObserver(() => setDark(document.documentElement.classList.contains('dark')));
@@ -324,8 +291,7 @@ export default function CourseListPage() {
 
   const fetchAll = async () => {
     try {
-      setLoading(true);
-      setError(null);
+      setLoading(true); setError(null);
       const [active, disabled] = await Promise.all([
         getCourses(),
         getDisabledCourses().catch(() => []),
@@ -340,79 +306,54 @@ export default function CourseListPage() {
     }
   };
 
-  const handleCourseAdded = () => fetchAll();
-  const handleCourseUpdated = () => fetchAll();
+  const handleCourseAdded    = () => fetchAll();
+  const handleCourseUpdated  = () => fetchAll();
   const handleCourseDisabled = () => { setDisablingCourse(null); fetchAll(); };
-  const handleEnable = async (course) => {
-    try {
-      await enableCourse(course.id);
-      fetchAll();
-    } catch { /* handle silently */ }
+  const handleEnable         = async (course) => {
+    try { await enableCourse(course.id); fetchAll(); } catch { /* silent */ }
   };
 
   const sourceList = activeTab === 'active' ? courses : disabledCourses;
 
   const filtered = sourceList.filter(c => {
-    const matchSearch =
-      c.courseCode?.toLowerCase().includes(search.toLowerCase()) ||
-      c.courseTitle?.toLowerCase().includes(search.toLowerCase());
-    const matchYear = filterYear === 'All' || String(c.yearLevel) === filterYear;
-    const matchSem = filterSem === 'All' || String(c.semester) === filterSem;
-    const matchPrereq =
-      filterPrereq === 'All' ||
-      (filterPrereq === 'with' && c.prerequisites?.length > 0) ||
-      (filterPrereq === 'none' && (!c.prerequisites || c.prerequisites.length === 0));
+    const matchSearch  = c.courseCode?.toLowerCase().includes(search.toLowerCase()) || c.courseTitle?.toLowerCase().includes(search.toLowerCase());
+    const matchYear    = filterYear   === 'All' || String(c.yearLevel) === filterYear;
+    const matchSem     = filterSem    === 'All' || String(c.semester)  === filterSem;
+    const matchPrereq  =
+      filterPrereq === 'All'  ? true :
+      filterPrereq === 'with' ? c.prerequisites?.length > 0 :
+                                (!c.prerequisites || c.prerequisites.length === 0);
     return matchSearch && matchYear && matchSem && matchPrereq;
   }).sort((a, b) => {
     if (sortBy === 'title') return a.courseTitle?.localeCompare(b.courseTitle);
-    if (sortBy === 'code') return a.courseCode?.localeCompare(b.courseCode);
+    if (sortBy === 'code')  return a.courseCode?.localeCompare(b.courseCode);
     if (sortBy === 'units') return b.units - a.units;
-    // default: year then sem
     const semOrder = { '1': 0, '2': 1, 'Summer': 2 };
     if (a.yearLevel !== b.yearLevel) return a.yearLevel - b.yearLevel;
     return (semOrder[String(a.semester)] ?? 9) - (semOrder[String(b.semester)] ?? 9);
   });
 
   const activeFilters = (filterYear !== 'All' ? 1 : 0) + (filterSem !== 'All' ? 1 : 0) + (filterPrereq !== 'All' ? 1 : 0);
-  const clearFilters = () => { setFilterYear('All'); setFilterSem('All'); setFilterPrereq('All'); setSearch(''); setSortBy('default'); };
+  const clearFilters  = () => { setFilterYear('All'); setFilterSem('All'); setFilterPrereq('All'); setSearch(''); setSortBy('default'); };
 
-  const yearOptions = [
-    { value: 'All', label: 'All years' },
-    { value: '1', label: 'Year 1' }, { value: '2', label: 'Year 2' },
-    { value: '3', label: 'Year 3' }, { value: '4', label: 'Year 4' },
-  ];
-  const semOptions = [
-    { value: 'All', label: 'All semesters' },
-    { value: '1', label: 'Semester 1' }, { value: '2', label: 'Semester 2' }, { value: 'Summer', label: 'Summer' },
-  ];
-  const prereqOptions = [
-    { value: 'All', label: 'All courses' },
-    { value: 'with', label: 'With prerequisites' }, { value: 'none', label: 'No prerequisites' },
-  ];
-  const sortOptions = [
-    { value: 'default', label: 'Year → Semester' },
-    { value: 'title', label: 'Title (A–Z)' },
-    { value: 'code', label: 'Code (A–Z)' },
-    { value: 'units', label: 'Units (High–Low)' },
-  ];
+  const yearOptions  = [{ value: 'All', label: 'All years' }, { value: '1', label: 'Year 1' }, { value: '2', label: 'Year 2' }, { value: '3', label: 'Year 3' }, { value: '4', label: 'Year 4' }];
+  const semOptions   = [{ value: 'All', label: 'All semesters' }, { value: '1', label: 'Semester 1' }, { value: '2', label: 'Semester 2' }, { value: 'Summer', label: 'Summer' }];
+  const prereqOptions= [{ value: 'All', label: 'All courses' }, { value: 'with', label: 'With prerequisites' }, { value: 'none', label: 'No prerequisites' }];
+  const sortOptions  = [{ value: 'default', label: 'Year → Semester' }, { value: 'title', label: 'Title (A–Z)' }, { value: 'code', label: 'Code (A–Z)' }, { value: 'units', label: 'Units (High–Low)' }];
 
-  const bg = dark ? '#0f172a' : '#f9fafb';
-  const cardBg = dark ? '#111827' : '#fff';
-  const border = dark ? '#1f2937' : '#e5e7eb';
-  const textPrimary = dark ? '#f9fafb' : '#111827';
-  const textSecondary = dark ? '#9ca3af' : '#6b7280';
-  const tableHeaderBg = dark ? '#1a2234' : '#f8fafc';
-  const rowHover = dark ? '#1a2234' : '#f8fafc';
-  const filterBg = dark ? '#161f2e' : '#fafafa';
+  const bg           = dark ? '#0f172a' : '#f9fafb';
+  const cardBg       = dark ? '#111827' : '#fff';
+  const border       = dark ? '#1f2937' : '#e5e7eb';
+  const textPrimary  = dark ? '#f9fafb' : '#111827';
+  const textSecondary= dark ? '#9ca3af' : '#6b7280';
+  const tableHeaderBg= dark ? '#1a2234' : '#f8fafc';
+  const rowHover     = dark ? '#1a2234' : '#f8fafc';
+  const filterBg     = dark ? '#161f2e' : '#fafafa';
 
   if (loading) return (
     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '60vh', background: bg }}>
       <div style={{ textAlign: 'center' }}>
-        <div style={{
-          width: 36, height: 36, border: `2px solid ${dark ? '#1f2937' : '#dbeafe'}`,
-          borderTop: '2px solid #2563eb', borderRadius: '50%', margin: '0 auto 12px',
-          animation: 'spin 0.8s linear infinite',
-        }} />
+        <div style={{ width: 36, height: 36, border: `2px solid ${dark ? '#1f2937' : '#dbeafe'}`, borderTop: '2px solid #2563eb', borderRadius: '50%', margin: '0 auto 12px', animation: 'spin 0.8s linear infinite' }} />
         <p style={{ fontSize: 13, color: textSecondary, fontFamily: "'DM Sans',system-ui,sans-serif" }}>Loading courses…</p>
       </div>
     </div>
@@ -425,17 +366,13 @@ export default function CourseListPage() {
   );
 
   return (
-    <div style={{
-      maxWidth: 1280, margin: '0 auto', padding: '28px 24px',
-      fontFamily: "'DM Sans', system-ui, sans-serif",
-    }}>
+    <div style={{ maxWidth: 1280, margin: '0 auto', padding: '28px 24px', fontFamily: "'DM Sans', system-ui, sans-serif" }}>
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=DM+Mono:wght@400;500;600&display=swap');
-        @keyframes dropIn { from{opacity:0;transform:translateY(-6px)} to{opacity:1;transform:translateY(0)} }
+        @keyframes dropIn   { from{opacity:0;transform:translateY(-6px)} to{opacity:1;transform:translateY(0)} }
         @keyframes drawerIn { from{opacity:0;transform:translateX(24px)} to{opacity:1;transform:translateX(0)} }
-        @keyframes fadeIn { from{opacity:0} to{opacity:1} }
-        @keyframes spin { to{transform:rotate(360deg)} }
-        @keyframes fadeUp { from{opacity:0;transform:translateY(12px)} to{opacity:1;transform:translateY(0)} }
+        @keyframes fadeIn   { from{opacity:0} to{opacity:1} }
+        @keyframes spin     { to{transform:rotate(360deg)} }
+        @keyframes fadeUp   { from{opacity:0;transform:translateY(12px)} to{opacity:1;transform:translateY(0)} }
         .cl-row { transition: background 0.12s; }
         .cl-row:hover { background: ${rowHover} !important; }
         .cl-icon-btn { width:30px;height:30px;border-radius:8px;border:none;display:inline-flex;align-items:center;justify-content:center;cursor:pointer;transition:all 0.15s;flex-shrink:0; }
@@ -447,41 +384,24 @@ export default function CourseListPage() {
       `}</style>
 
       {/* ── Page header ── */}
-      <div className="anim-in" style={{
-        animationDelay: '0.03s',
-        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-        gap: 12, flexWrap: 'wrap', marginBottom: 20,
-      }}>
+      <div className="anim-in" style={{ animationDelay: '0.03s', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap', marginBottom: 20 }}>
         <div>
-          <p style={{ fontSize: 10, fontWeight: 700, letterSpacing: '.12em', textTransform: 'uppercase', color: '#2563eb', margin: '0 0 4px' }}>
-            Curriculum Management
-          </p>
+          <p style={{ fontSize: 10, fontWeight: 700, letterSpacing: '.12em', textTransform: 'uppercase', color: '#2563eb', margin: '0 0 4px' }}>Curriculum Management</p>
           <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
             <h1 style={{ fontSize: 26, fontWeight: 700, color: textPrimary, margin: 0, letterSpacing: '-0.02em' }}>Courses</h1>
-            <span style={{
-              padding: '3px 10px', borderRadius: 999, fontSize: 12, fontWeight: 500,
-              background: dark ? '#1f2937' : '#f3f4f6', color: textSecondary,
-            }}>
+            <span style={{ padding: '3px 10px', borderRadius: 999, fontSize: 12, fontWeight: 500, background: dark ? '#1f2937' : '#f3f4f6', color: textSecondary }}>
               {courses.length} active
             </span>
           </div>
         </div>
 
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
-          {/* Search */}
-          <div className="search-wrap" style={{
-            background: cardBg, border: `1px solid ${border}`,
-            color: textPrimary,
-          }}>
+          <div className="search-wrap" style={{ background: cardBg, border: `1px solid ${border}`, color: textPrimary }}>
             <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
               <circle cx="7" cy="7" r="5.5" stroke={textSecondary} strokeWidth="1.4"/>
               <path d="M11.5 11.5l2.5 2.5" stroke={textSecondary} strokeWidth="1.4" strokeLinecap="round"/>
             </svg>
-            <input
-              type="text" placeholder="Search courses…"
-              value={search} onChange={e => setSearch(e.target.value)}
-              style={{ color: textPrimary }}
-            />
+            <input type="text" placeholder="Search courses…" value={search} onChange={e => setSearch(e.target.value)} style={{ color: textPrimary }} />
             {search && (
               <button onClick={() => setSearch('')} style={{ background: 'none', border: 'none', cursor: 'pointer', color: textSecondary, padding: 0, display: 'flex' }}>
                 <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
@@ -491,36 +411,26 @@ export default function CourseListPage() {
             )}
           </div>
 
-          {/* Export CSV */}
           <button onClick={() => exportToCSV(filtered, `courses-${activeTab}`)} style={{
-            display: 'inline-flex', alignItems: 'center', gap: 6,
-            padding: '8px 14px', borderRadius: 10,
-            border: `1px solid ${border}`, background: cardBg,
-            color: textSecondary, fontSize: 13, fontWeight: 600,
-            fontFamily: 'inherit', cursor: 'pointer', transition: 'all 0.15s',
-          }}
-            onMouseEnter={e => e.currentTarget.style.borderColor = '#2563eb'}
-            onMouseLeave={e => e.currentTarget.style.borderColor = border}
-          >
+            display: 'inline-flex', alignItems: 'center', gap: 6, padding: '8px 14px',
+            borderRadius: 10, border: `1px solid ${border}`, background: cardBg,
+            color: textSecondary, fontSize: 13, fontWeight: 600, fontFamily: 'inherit', cursor: 'pointer',
+          }}>
             <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
               <path d="M8 2v8M5 7l3 3 3-3M3 12h10" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
             Export CSV
           </button>
 
-          {/* Add Course */}
-          {isAdmin && (
+          {/* Add Course — admin & superadmin */}
+          {canWrite && (
             <button onClick={() => setIsAddOpen(true)} style={{
-              display: 'inline-flex', alignItems: 'center', gap: 6,
-              padding: '8px 16px', borderRadius: 10,
-              background: 'linear-gradient(135deg,#1d4ed8,#2563eb)',
+              display: 'inline-flex', alignItems: 'center', gap: 6, padding: '8px 16px',
+              borderRadius: 10, background: 'linear-gradient(135deg,#1d4ed8,#2563eb)',
               color: '#fff', border: 'none', fontSize: 13, fontWeight: 600,
-              fontFamily: 'inherit', cursor: 'pointer', transition: 'all 0.15s',
+              fontFamily: 'inherit', cursor: 'pointer',
               boxShadow: '0 2px 10px rgba(37,99,235,0.35)',
-            }}
-              onMouseEnter={e => { e.currentTarget.style.transform = 'translateY(-1px)'; e.currentTarget.style.boxShadow = '0 4px 16px rgba(37,99,235,0.45)'; }}
-              onMouseLeave={e => { e.currentTarget.style.transform = 'none'; e.currentTarget.style.boxShadow = '0 2px 10px rgba(37,99,235,0.35)'; }}
-            >
+            }}>
               <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
                 <path d="M7 1v12M1 7h12" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
               </svg>
@@ -531,107 +441,68 @@ export default function CourseListPage() {
       </div>
 
       {/* ── Table card ── */}
-      <div className="anim-in" style={{
-        animationDelay: '0.09s',
-        background: cardBg, border: `1px solid ${border}`,
-        borderRadius: 14, overflow: 'hidden',
-      }}>
+      <div className="anim-in" style={{ animationDelay: '0.09s', background: cardBg, border: `1px solid ${border}`, borderRadius: 14, overflow: 'hidden' }}>
 
-        {/* ── Tabs ── */}
-        <div style={{
-          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-          padding: '0 20px', borderBottom: `1px solid ${border}`,
-          background: dark ? '#161f2e' : '#fafbfc', flexWrap: 'wrap', gap: 8,
-        }}>
+        {/* Tabs — disabled tab hidden for regular users */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 20px', borderBottom: `1px solid ${border}`, background: dark ? '#161f2e' : '#fafbfc', flexWrap: 'wrap', gap: 8 }}>
           <div style={{ display: 'flex', gap: 0 }}>
             {[
-              { key: 'active', label: 'Active Courses', count: courses.length },
-              { key: 'disabled', label: 'Archived', count: disabledCourses.length },
-            ].map(tab => (
-              <button key={tab.key} onClick={() => { setActiveTab(tab.key); setSearch(''); }}
-                style={{
-                  padding: '13px 16px', background: 'none', border: 'none',
-                  borderBottom: activeTab === tab.key ? '2px solid #2563eb' : '2px solid transparent',
-                  color: activeTab === tab.key ? '#2563eb' : textSecondary,
-                  fontSize: 13, fontWeight: activeTab === tab.key ? 700 : 500,
-                  cursor: 'pointer', fontFamily: 'inherit', transition: 'all 0.15s',
-                  display: 'flex', alignItems: 'center', gap: 7, marginBottom: -1,
-                }}
-              >
+              { key: 'active', label: 'Active Courses', count: courses.length, visible: true },
+              { key: 'disabled', label: 'Archived', count: disabledCourses.length, visible: canSeeDisabledTab },
+            ].filter(tab => tab.visible).map(tab => (
+              <button key={tab.key} onClick={() => { setActiveTab(tab.key); setSearch(''); }} style={{
+                padding: '13px 16px', background: 'none', border: 'none',
+                borderBottom: activeTab === tab.key ? '2px solid #2563eb' : '2px solid transparent',
+                color: activeTab === tab.key ? '#2563eb' : textSecondary,
+                fontSize: 13, fontWeight: activeTab === tab.key ? 700 : 500,
+                cursor: 'pointer', fontFamily: 'inherit', display: 'flex', alignItems: 'center', gap: 7, marginBottom: -1,
+              }}>
                 {tab.label}
-                <span style={{
-                  padding: '1px 7px', borderRadius: 999, fontSize: 11, fontWeight: 600,
-                  background: activeTab === tab.key ? (dark ? '#1e3a5f' : '#dbeafe') : (dark ? '#1f2937' : '#f3f4f6'),
-                  color: activeTab === tab.key ? '#2563eb' : textSecondary,
-                }}>
+                <span style={{ padding: '1px 7px', borderRadius: 999, fontSize: 11, fontWeight: 600, background: activeTab === tab.key ? (dark ? '#1e3a5f' : '#dbeafe') : (dark ? '#1f2937' : '#f3f4f6'), color: activeTab === tab.key ? '#2563eb' : textSecondary }}>
                   {tab.count}
                 </span>
               </button>
             ))}
           </div>
 
-          {!isAdmin && (
-            <span style={{
-              display: 'inline-flex', alignItems: 'center', gap: 5,
-              padding: '4px 10px', borderRadius: 7,
-              background: dark ? '#292000' : '#fefce8', border: `1px solid ${dark ? '#854d0e' : '#fde68a'}`,
-              color: dark ? '#fbbf24' : '#92400e', fontSize: 11, fontWeight: 500,
-            }}>
-              <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.4"/>
-                <path d="M7 6v4M7 4.5V5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
-              </svg>
-              View only
+          {/* Role notice */}
+          {isAdmin && !isSuperAdmin && (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 10px', borderRadius: 7, background: dark ? '#292000' : '#fefce8', border: `1px solid ${dark ? '#854d0e' : '#fde68a'}`, color: dark ? '#fbbf24' : '#92400e', fontSize: 11, fontWeight: 500 }}>
+              ✏️ Edit & Restore only — Archive requires Superadmin
+            </span>
+          )}
+          {!canWrite && (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 10px', borderRadius: 7, background: dark ? '#292000' : '#fefce8', border: `1px solid ${dark ? '#854d0e' : '#fde68a'}`, color: dark ? '#fbbf24' : '#92400e', fontSize: 11, fontWeight: 500 }}>
+              👁️ View only
             </span>
           )}
         </div>
 
-        {/* ── Filter bar ── */}
-        <div style={{
-          display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap',
-          padding: '10px 16px', borderBottom: `1px solid ${border}`, background: filterBg,
-        }}>
-          <FilterDropdown label="Year" value={filterYear} options={yearOptions} onChange={setFilterYear} dark={dark} />
+        {/* Filter bar */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', padding: '10px 16px', borderBottom: `1px solid ${border}`, background: filterBg }}>
+          <FilterDropdown label="Year"          value={filterYear}   options={yearOptions}   onChange={setFilterYear}   dark={dark} />
           <div style={{ width: 1, height: 22, background: border }} />
-          <FilterDropdown label="Semester" value={filterSem} options={semOptions} onChange={setFilterSem} dark={dark} />
+          <FilterDropdown label="Semester"      value={filterSem}    options={semOptions}    onChange={setFilterSem}    dark={dark} />
           <div style={{ width: 1, height: 22, background: border }} />
           <FilterDropdown label="Prerequisites" value={filterPrereq} options={prereqOptions} onChange={setFilterPrereq} dark={dark} />
           <div style={{ width: 1, height: 22, background: border }} />
-          <FilterDropdown label="Sort by" value={sortBy} options={sortOptions} onChange={setSortBy} dark={dark} />
-
+          <FilterDropdown label="Sort by"       value={sortBy}       options={sortOptions}   onChange={setSortBy}       dark={dark} />
           {(activeFilters > 0 || search || sortBy !== 'default') && (
-            <button onClick={clearFilters} style={{
-              display: 'inline-flex', alignItems: 'center', gap: 4,
-              padding: '5px 10px', borderRadius: 7,
-              background: dark ? '#3b0f14' : '#fee2e2', color: dark ? '#fca5a5' : '#dc2626',
-              border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit',
-            }}>
+            <button onClick={clearFilters} style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '5px 10px', borderRadius: 7, background: dark ? '#3b0f14' : '#fee2e2', color: dark ? '#fca5a5' : '#dc2626', border: 'none', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}>
               ✕ Clear
             </button>
           )}
-
-          <span style={{ marginLeft: 'auto', fontSize: 12, color: textSecondary }}>
-            {filtered.length} result{filtered.length !== 1 ? 's' : ''}
-          </span>
+          <span style={{ marginLeft: 'auto', fontSize: 12, color: textSecondary }}>{filtered.length} result{filtered.length !== 1 ? 's' : ''}</span>
         </div>
 
-        {/* ── Table / Empty State ── */}
+        {/* Table / Empty */}
         {filtered.length === 0 ? (
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '64px 24px', color: textSecondary }}>
-            <div style={{
-              width: 52, height: 52, borderRadius: 14, marginBottom: 16,
-              background: dark ? '#1f2937' : '#f3f4f6',
-              display: 'flex', alignItems: 'center', justifyContent: 'center',
-            }}>
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                <path d="M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 0 0 2 2h2a2 2 0 0 0 2-2M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2" stroke={dark ? '#4b5563' : '#d1d5db'} strokeWidth="1.5" strokeLinecap="round"/>
-              </svg>
-            </div>
-            <p style={{ fontSize: 14, fontWeight: 600, color: textSecondary, marginBottom: 4 }}>
+            <p style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>
               {search || activeFilters > 0 ? 'No courses match your filters' : activeTab === 'disabled' ? 'No archived courses' : 'No courses yet'}
             </p>
             <p style={{ fontSize: 12, color: dark ? '#4b5563' : '#9ca3af' }}>
-              {search || activeFilters > 0 ? 'Try adjusting your search or filters' : isAdmin ? 'Click "Add New Course" to get started' : 'No courses have been added yet'}
+              {search || activeFilters > 0 ? 'Try adjusting your search or filters' : canWrite ? 'Click "Add New Course" to get started' : 'No courses have been added yet'}
             </p>
           </div>
         ) : (
@@ -640,108 +511,63 @@ export default function CourseListPage() {
               <thead>
                 <tr style={{ background: tableHeaderBg }}>
                   {['Code', 'Title', 'Units', 'Year & Sem', 'Prerequisites', 'Actions'].map(h => (
-                    <th key={h} style={{
-                      padding: '10px 16px', textAlign: h === 'Units' ? 'center' : 'left',
-                      fontSize: 11, fontWeight: 700, color: textSecondary,
-                      letterSpacing: '.07em', textTransform: 'uppercase',
-                      borderBottom: `1px solid ${border}`, whiteSpace: 'nowrap',
-                    }}>{h}</th>
+                    <th key={h} style={{ padding: '10px 16px', textAlign: h === 'Units' ? 'center' : 'left', fontSize: 11, fontWeight: 700, color: textSecondary, letterSpacing: '.07em', textTransform: 'uppercase', borderBottom: `1px solid ${border}`, whiteSpace: 'nowrap' }}>{h}</th>
                   ))}
                 </tr>
               </thead>
               <tbody>
                 {filtered.map((course, idx) => {
-                  const yc = yearColors[course.yearLevel] || yearColors[1];
-                  const prereqs = course.prerequisites || [];
-                  const isDrawerOpen = drawerCourse?.id === course.id;
+                  const yc          = yearColors[course.yearLevel] || yearColors[1];
+                  const prereqs     = course.prerequisites || [];
+                  const isDrawerOpen= drawerCourse?.id === course.id;
 
                   return (
-                    <tr key={course.id} className="cl-row" style={{
-                      borderBottom: `1px solid ${border}`,
-                      background: isDrawerOpen ? (dark ? '#0c1e3d' : '#f0f7ff') : 'transparent',
-                      animation: `fadeUp 0.3s ease both`,
-                      animationDelay: `${idx * 0.03}s`,
-                    }}>
+                    <tr key={course.id} className="cl-row" style={{ borderBottom: `1px solid ${border}`, background: isDrawerOpen ? (dark ? '#0c1e3d' : '#f0f7ff') : 'transparent', animation: `fadeUp 0.3s ease both`, animationDelay: `${idx * 0.03}s` }}>
 
-                      {/* CODE */}
                       <td style={{ padding: '14px 16px', verticalAlign: 'middle' }}>
-                        <span style={{
-                          fontFamily: "'DM Mono','Fira Code',monospace",
-                          fontSize: 12, fontWeight: 600, color: textPrimary,
-                          letterSpacing: '0.02em',
-                        }}>
+                        <span style={{ fontFamily: "'DM Mono','Fira Code',monospace", fontSize: 12, fontWeight: 600, color: textPrimary, letterSpacing: '0.02em' }}>
                           {course.courseCode}
                         </span>
                       </td>
 
-                      {/* TITLE */}
                       <td style={{ padding: '14px 16px', verticalAlign: 'middle', maxWidth: 280 }}>
-                        <span style={{ fontSize: 14, fontWeight: 600, color: textPrimary, lineHeight: 1.3 }}>
-                          {course.courseTitle}
-                        </span>
+                        <span style={{ fontSize: 14, fontWeight: 600, color: textPrimary, lineHeight: 1.3 }}>{course.courseTitle}</span>
                       </td>
 
-                      {/* UNITS */}
                       <td style={{ padding: '14px 16px', verticalAlign: 'middle', textAlign: 'center' }}>
                         <span style={{ fontSize: 13, fontWeight: 600, color: textSecondary }}>{course.units}</span>
                       </td>
 
-                      {/* YEAR + SEM combined */}
                       <td style={{ padding: '14px 16px', verticalAlign: 'middle' }}>
-                        <span style={{
-                          display: 'inline-flex', alignItems: 'center', gap: 5,
-                          padding: '4px 10px', borderRadius: 999, fontSize: 12, fontWeight: 600,
-                          background: dark ? yc.darkBg : yc.bg,
-                          color: dark ? yc.darkText : yc.text,
-                          whiteSpace: 'nowrap',
-                        }}>
+                        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 10px', borderRadius: 999, fontSize: 12, fontWeight: 600, background: dark ? yc.darkBg : yc.bg, color: dark ? yc.darkText : yc.text, whiteSpace: 'nowrap' }}>
                           <span style={{ width: 6, height: 6, borderRadius: '50%', background: dark ? yc.darkText : yc.dot, display: 'inline-block', flexShrink: 0 }} />
                           {formatYearSemester(course.yearLevel, course.semester)}
                         </span>
                       </td>
 
-                      {/* PREREQUISITES */}
                       <td style={{ padding: '14px 16px', verticalAlign: 'middle' }}>
                         {prereqs.length === 0 ? (
                           <span style={{ fontSize: 12, color: dark ? '#4b5563' : '#d1d5db', fontStyle: 'italic' }}>None</span>
                         ) : (
                           <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'nowrap' }}>
                             {prereqs.slice(0, 2).map(p => (
-                              <span key={p} style={{
-                                fontFamily: "'DM Mono','Fira Code',monospace",
-                                fontSize: 11, padding: '2px 7px', borderRadius: 6,
-                                background: dark ? '#1e3a5f' : '#eff6ff',
-                                color: dark ? '#93c5fd' : '#1d4ed8',
-                                border: `1px solid ${dark ? '#1d4ed8' : '#bfdbfe'}`,
-                                fontWeight: 500, whiteSpace: 'nowrap',
-                              }}>{p}</span>
+                              <span key={p} style={{ fontFamily: "'DM Mono','Fira Code',monospace", fontSize: 11, padding: '2px 7px', borderRadius: 6, background: dark ? '#1e3a5f' : '#eff6ff', color: dark ? '#93c5fd' : '#1d4ed8', border: `1px solid ${dark ? '#1d4ed8' : '#bfdbfe'}`, fontWeight: 500, whiteSpace: 'nowrap' }}>{p}</span>
                             ))}
                             {prereqs.length > 2 && (
-                              <span style={{
-                                fontSize: 11, padding: '2px 7px', borderRadius: 999,
-                                background: dark ? '#1f2937' : '#f3f4f6',
-                                color: textSecondary, fontWeight: 600,
-                              }}>+{prereqs.length - 2}</span>
+                              <span style={{ fontSize: 11, padding: '2px 7px', borderRadius: 999, background: dark ? '#1f2937' : '#f3f4f6', color: textSecondary, fontWeight: 600 }}>+{prereqs.length - 2}</span>
                             )}
                           </div>
                         )}
                       </td>
-
-                      {/* ACTIONS */}
+                      
                       <td style={{ padding: '14px 16px', verticalAlign: 'middle' }}>
                         <div style={{ display: 'flex', gap: 5, alignItems: 'center' }}>
 
-                          {/* Details */}
+                          {/* Details — everyone */}
                           <Tooltip text="Knowledge Details">
                             <button className="cl-icon-btn"
                               onClick={() => setDrawerCourse(isDrawerOpen ? null : course)}
-                              style={{
-                                background: isDrawerOpen
-                                  ? '#1d4ed8'
-                                  : (dark ? '#1e3a5f' : '#eff6ff'),
-                                color: isDrawerOpen ? '#fff' : (dark ? '#93c5fd' : '#1d4ed8'),
-                                border: `1px solid ${dark ? '#1d4ed8' : '#bfdbfe'}`,
-                              }}>
+                              style={{ background: isDrawerOpen ? '#1d4ed8' : (dark ? '#1e3a5f' : '#eff6ff'), color: isDrawerOpen ? '#fff' : (dark ? '#93c5fd' : '#1d4ed8'), border: `1px solid ${dark ? '#1d4ed8' : '#bfdbfe'}` }}>
                               <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
                                 <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.4"/>
                                 <path d="M7 6v4M7 4.5V5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
@@ -749,49 +575,38 @@ export default function CourseListPage() {
                             </button>
                           </Tooltip>
 
-                          {isAdmin && activeTab === 'active' && (
-                            <>
-                              {/* Edit */}
-                              <Tooltip text="Edit Course">
-                                <button className="cl-icon-btn"
-                                  onClick={() => setEditingCourse(course)}
-                                  style={{
-                                    background: dark ? '#1f2937' : '#f8fafc',
-                                    color: dark ? '#9ca3af' : '#374151',
-                                    border: `1px solid ${border}`,
-                                  }}>
-                                  <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
-                                    <path d="M9.5 2.5l2 2-7 7H2.5v-2l7-7z" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
-                                  </svg>
-                                </button>
-                              </Tooltip>
-
-                              {/* Archive */}
-                              <Tooltip text="Archive Course">
-                                <button className="cl-icon-btn"
-                                  onClick={() => setDisablingCourse(course)}
-                                  style={{
-                                    background: dark ? '#2d0a14' : '#fff1f2',
-                                    color: dark ? '#fca5a5' : '#be123c',
-                                    border: `1px solid ${dark ? '#7f1d1d' : '#fecdd3'}`,
-                                  }}>
-                                  <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
-                                    <path d="M2 4h10M5 4V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1M6 7v3M8 7v3M3 4l.7 7a1 1 0 0 0 1 .9h4.6a1 1 0 0 0 1-.9L11 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
-                                  </svg>
-                                </button>
-                              </Tooltip>
-                            </>
+                          {/* Edit — admin & superadmin */}
+                          {canWrite && activeTab === 'active' && (
+                            <Tooltip text="Edit Course">
+                              <button className="cl-icon-btn"
+                                onClick={() => setEditingCourse(course)}
+                                style={{ background: dark ? '#1f2937' : '#f8fafc', color: dark ? '#9ca3af' : '#374151', border: `1px solid ${border}` }}>
+                                <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+                                  <path d="M9.5 2.5l2 2-7 7H2.5v-2l7-7z" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+                                </svg>
+                              </button>
+                            </Tooltip>
                           )}
 
-                          {isAdmin && activeTab === 'disabled' && (
+                          {/* Archive — SUPERADMIN ONLY (only on active tab) */}
+                          {canArchive && activeTab === 'active' && (
+                            <Tooltip text="Archive Course">
+                              <button className="cl-icon-btn"
+                                onClick={() => setDisablingCourse(course)}
+                                style={{ background: dark ? '#2d0a14' : '#fff1f2', color: dark ? '#fca5a5' : '#be123c', border: `1px solid ${dark ? '#7f1d1d' : '#fecdd3'}` }}>
+                                <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+                                  <path d="M2 4h10M5 4V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1M6 7v3M8 7v3M3 4l.7 7a1 1 0 0 0 1 .9h4.6a1 1 0 0 0 1-.9L11 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+                                </svg>
+                              </button>
+                            </Tooltip>
+                          )}
+
+                          {/* Restore — ADMIN & SUPERADMIN (only on disabled tab) */}
+                          {canRestore && activeTab === 'disabled' && (
                             <Tooltip text="Restore Course">
                               <button className="cl-icon-btn"
                                 onClick={() => handleEnable(course)}
-                                style={{
-                                  background: dark ? '#0a2e1a' : '#f0fdf4',
-                                  color: dark ? '#86efac' : '#15803d',
-                                  border: `1px solid ${dark ? '#166534' : '#bbf7d0'}`,
-                                }}>
+                                style={{ background: dark ? '#0a2e1a' : '#f0fdf4', color: dark ? '#86efac' : '#15803d', border: `1px solid ${dark ? '#166534' : '#bbf7d0'}` }}>
                                 <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
                                   <path d="M2 7a5 5 0 1 1 1.5 3.6M2 11V7h4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
                                 </svg>
@@ -815,16 +630,18 @@ export default function CourseListPage() {
         </p>
       )}
 
-      {/* Knowledge Drawer */}
       {drawerCourse && <KnowledgeDrawer course={drawerCourse} onClose={() => setDrawerCourse(null)} dark={dark} />}
 
-      {/* Modals */}
-      {isAdmin && (
+      {canWrite && (
         <>
           <AddCourseModal isOpen={isAddOpen} onClose={() => setIsAddOpen(false)} onCourseAdded={handleCourseAdded} allCourses={courses} />
           <EditCourseModal isOpen={editingCourse !== null} onClose={() => setEditingCourse(null)} onCourseUpdated={handleCourseUpdated} course={editingCourse} allCourses={courses} />
-          <SoftDisableConfirmDialog isOpen={disablingCourse !== null} onClose={() => setDisablingCourse(null)} onDisabled={handleCourseDisabled} courseId={disablingCourse?.id} courseCode={disablingCourse?.courseCode} />
         </>
+      )}
+
+      {/* Archive dialog only shown for superadmin */}
+      {canArchive && (
+        <SoftDisableConfirmDialog isOpen={disablingCourse !== null} onClose={() => setDisablingCourse(null)} onDisabled={handleCourseDisabled} courseId={disablingCourse?.id} courseCode={disablingCourse?.courseCode} />
       )}
     </div>
   );

--- a/src/pages/CourseListPage.jsx
+++ b/src/pages/CourseListPage.jsx
@@ -1,9 +1,4 @@
 // src/pages/CourseListPage.jsx
-// CHANGES:
-// - Only superadmins see the Archive button. Admins can Restore (from disabled tab) but not Archive.
-// - Disabled tab is hidden for regular users (visible only to admins and superadmins).
-// - All other functionality unchanged.
-
 import React, { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import AddCourseModal from '../components/AddCourseModal';
@@ -259,10 +254,10 @@ export default function CourseListPage() {
   // ── ROLE CHECKS ──────────────────────────────────────────────────────────
   const isSuperAdmin = role === 'superadmin';
   const isAdmin      = role === 'admin';
-  const canWrite     = isSuperAdmin || isAdmin;           // add/edit/detail
-  const canArchive   = isSuperAdmin;                      // only superadmin can archive
-  const canRestore   = isSuperAdmin || isAdmin;           // admin & superadmin can restore
-  const canSeeDisabledTab = isSuperAdmin || isAdmin;      // regular users should NOT see archived tab
+  const canWrite     = isSuperAdmin || isAdmin;           
+  const canArchive   = isSuperAdmin || isAdmin;           
+  const canRestore   = isSuperAdmin || isAdmin;       
+  const canSeeDisabledTab = isSuperAdmin || isAdmin;     
 
   const [courses, setCourses] = useState([]);
   const [disabledCourses, setDisabledCourses] = useState([]);
@@ -279,6 +274,10 @@ export default function CourseListPage() {
   const [filterPrereq, setFilterPrereq] = useState('All');
   const [sortBy, setSortBy] = useState('default');
   const [visible, setVisible] = useState(false);
+
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 20;
 
   const [dark, setDark] = useState(() => document.documentElement.classList.contains('dark'));
   useEffect(() => {
@@ -315,6 +314,7 @@ export default function CourseListPage() {
 
   const sourceList = activeTab === 'active' ? courses : disabledCourses;
 
+  // Filter and sort
   const filtered = sourceList.filter(c => {
     const matchSearch  = c.courseCode?.toLowerCase().includes(search.toLowerCase()) || c.courseTitle?.toLowerCase().includes(search.toLowerCase());
     const matchYear    = filterYear   === 'All' || String(c.yearLevel) === filterYear;
@@ -332,6 +332,16 @@ export default function CourseListPage() {
     if (a.yearLevel !== b.yearLevel) return a.yearLevel - b.yearLevel;
     return (semOrder[String(a.semester)] ?? 9) - (semOrder[String(b.semester)] ?? 9);
   });
+
+  // Reset to first page when filters, search, or tab changes
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [activeTab, search, filterYear, filterSem, filterPrereq, sortBy]);
+
+  // Pagination calculations
+  const totalPages = Math.ceil(filtered.length / itemsPerPage);
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const paginatedCourses = filtered.slice(startIndex, startIndex + itemsPerPage);
 
   const activeFilters = (filterYear !== 'All' ? 1 : 0) + (filterSem !== 'All' ? 1 : 0) + (filterPrereq !== 'All' ? 1 : 0);
   const clearFilters  = () => { setFilterYear('All'); setFilterSem('All'); setFilterPrereq('All'); setSearch(''); setSortBy('default'); };
@@ -381,6 +391,33 @@ export default function CourseListPage() {
         .search-wrap { display:flex;align-items:center;gap:8px;border-radius:10px;padding:0 12px;height:38px;width:220px;transition:border-color 0.2s,box-shadow 0.2s; }
         .search-wrap:focus-within { box-shadow:0 0 0 3px rgba(147,197,253,0.2); }
         .search-wrap input { border:none;outline:none;font-size:13px;background:transparent;width:100%;font-family:inherit; }
+        
+        /* Pagination styles */
+        .pagination-btn {
+          padding: 6px 12px;
+          border-radius: 8px;
+          font-size: 13px;
+          font-weight: 500;
+          background: ${cardBg};
+          border: 1px solid ${border};
+          color: ${textSecondary};
+          cursor: pointer;
+          transition: all 0.15s;
+        }
+        .pagination-btn:hover:not(:disabled) {
+          background: ${dark ? '#1f2937' : '#f3f4f6'};
+          border-color: #2563eb;
+          color: #2563eb;
+        }
+        .pagination-btn.active {
+          background: #2563eb;
+          border-color: #2563eb;
+          color: white;
+        }
+        .pagination-btn:disabled {
+          opacity: 0.4;
+          cursor: not-allowed;
+        }
       `}</style>
 
       {/* ── Page header ── */}
@@ -468,7 +505,7 @@ export default function CourseListPage() {
           {/* Role notice */}
           {isAdmin && !isSuperAdmin && (
             <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 10px', borderRadius: 7, background: dark ? '#292000' : '#fefce8', border: `1px solid ${dark ? '#854d0e' : '#fde68a'}`, color: dark ? '#fbbf24' : '#92400e', fontSize: 11, fontWeight: 500 }}>
-              ✏️ Edit & Restore only — Archive requires Superadmin
+              ✏️ Edit, Archive & Restore
             </span>
           )}
           {!canWrite && (
@@ -495,7 +532,7 @@ export default function CourseListPage() {
           <span style={{ marginLeft: 'auto', fontSize: 12, color: textSecondary }}>{filtered.length} result{filtered.length !== 1 ? 's' : ''}</span>
         </div>
 
-        {/* Table / Empty */}
+        {/* Table / Empty with pagination */}
         {filtered.length === 0 ? (
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '64px 24px', color: textSecondary }}>
             <p style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>
@@ -506,127 +543,179 @@ export default function CourseListPage() {
             </p>
           </div>
         ) : (
-          <div style={{ overflowX: 'auto' }}>
-            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-              <thead>
-                <tr style={{ background: tableHeaderBg }}>
-                  {['Code', 'Title', 'Units', 'Year & Sem', 'Prerequisites', 'Actions'].map(h => (
-                    <th key={h} style={{ padding: '10px 16px', textAlign: h === 'Units' ? 'center' : 'left', fontSize: 11, fontWeight: 700, color: textSecondary, letterSpacing: '.07em', textTransform: 'uppercase', borderBottom: `1px solid ${border}`, whiteSpace: 'nowrap' }}>{h}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {filtered.map((course, idx) => {
-                  const yc          = yearColors[course.yearLevel] || yearColors[1];
-                  const prereqs     = course.prerequisites || [];
-                  const isDrawerOpen= drawerCourse?.id === course.id;
+          <>
+            <div style={{ overflowX: 'auto' }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr style={{ background: tableHeaderBg }}>
+                    {['Code', 'Title', 'Units', 'Year & Sem', 'Prerequisites', 'Actions'].map(h => (
+                      <th key={h} style={{ padding: '10px 16px', textAlign: h === 'Units' ? 'center' : 'left', fontSize: 11, fontWeight: 700, color: textSecondary, letterSpacing: '.07em', textTransform: 'uppercase', borderBottom: `1px solid ${border}`, whiteSpace: 'nowrap' }}>{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {paginatedCourses.map((course, idx) => {
+                    const yc          = yearColors[course.yearLevel] || yearColors[1];
+                    const prereqs     = course.prerequisites || [];
+                    const isDrawerOpen= drawerCourse?.id === course.id;
 
-                  return (
-                    <tr key={course.id} className="cl-row" style={{ borderBottom: `1px solid ${border}`, background: isDrawerOpen ? (dark ? '#0c1e3d' : '#f0f7ff') : 'transparent', animation: `fadeUp 0.3s ease both`, animationDelay: `${idx * 0.03}s` }}>
+                    return (
+                      <tr key={course.id} className="cl-row" style={{ borderBottom: `1px solid ${border}`, background: isDrawerOpen ? (dark ? '#0c1e3d' : '#f0f7ff') : 'transparent', animation: `fadeUp 0.3s ease both`, animationDelay: `${idx * 0.03}s` }}>
 
-                      <td style={{ padding: '14px 16px', verticalAlign: 'middle' }}>
-                        <span style={{ fontFamily: "'DM Mono','Fira Code',monospace", fontSize: 12, fontWeight: 600, color: textPrimary, letterSpacing: '0.02em' }}>
-                          {course.courseCode}
-                        </span>
-                      </td>
+                        <td style={{ padding: '14px 16px', verticalAlign: 'middle' }}>
+                          <span style={{ fontFamily: "'DM Mono','Fira Code',monospace", fontSize: 12, fontWeight: 600, color: textPrimary, letterSpacing: '0.02em' }}>
+                            {course.courseCode}
+                          </span>
+                        </td>
 
-                      <td style={{ padding: '14px 16px', verticalAlign: 'middle', maxWidth: 280 }}>
-                        <span style={{ fontSize: 14, fontWeight: 600, color: textPrimary, lineHeight: 1.3 }}>{course.courseTitle}</span>
-                      </td>
+                        <td style={{ padding: '14px 16px', verticalAlign: 'middle', maxWidth: 280 }}>
+                          <span style={{ fontSize: 14, fontWeight: 600, color: textPrimary, lineHeight: 1.3 }}>{course.courseTitle}</span>
+                        </td>
 
-                      <td style={{ padding: '14px 16px', verticalAlign: 'middle', textAlign: 'center' }}>
-                        <span style={{ fontSize: 13, fontWeight: 600, color: textSecondary }}>{course.units}</span>
-                      </td>
+                        <td style={{ padding: '14px 16px', verticalAlign: 'middle', textAlign: 'center' }}>
+                          <span style={{ fontSize: 13, fontWeight: 600, color: textSecondary }}>{course.units}</span>
+                        </td>
 
-                      <td style={{ padding: '14px 16px', verticalAlign: 'middle' }}>
-                        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 10px', borderRadius: 999, fontSize: 12, fontWeight: 600, background: dark ? yc.darkBg : yc.bg, color: dark ? yc.darkText : yc.text, whiteSpace: 'nowrap' }}>
-                          <span style={{ width: 6, height: 6, borderRadius: '50%', background: dark ? yc.darkText : yc.dot, display: 'inline-block', flexShrink: 0 }} />
-                          {formatYearSemester(course.yearLevel, course.semester)}
-                        </span>
-                      </td>
+                        <td style={{ padding: '14px 16px', verticalAlign: 'middle' }}>
+                          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 10px', borderRadius: 999, fontSize: 12, fontWeight: 600, background: dark ? yc.darkBg : yc.bg, color: dark ? yc.darkText : yc.text, whiteSpace: 'nowrap' }}>
+                            <span style={{ width: 6, height: 6, borderRadius: '50%', background: dark ? yc.darkText : yc.dot, display: 'inline-block', flexShrink: 0 }} />
+                            {formatYearSemester(course.yearLevel, course.semester)}
+                          </span>
+                        </td>
 
-                      <td style={{ padding: '14px 16px', verticalAlign: 'middle' }}>
-                        {prereqs.length === 0 ? (
-                          <span style={{ fontSize: 12, color: dark ? '#4b5563' : '#d1d5db', fontStyle: 'italic' }}>None</span>
-                        ) : (
-                          <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'nowrap' }}>
-                            {prereqs.slice(0, 2).map(p => (
-                              <span key={p} style={{ fontFamily: "'DM Mono','Fira Code',monospace", fontSize: 11, padding: '2px 7px', borderRadius: 6, background: dark ? '#1e3a5f' : '#eff6ff', color: dark ? '#93c5fd' : '#1d4ed8', border: `1px solid ${dark ? '#1d4ed8' : '#bfdbfe'}`, fontWeight: 500, whiteSpace: 'nowrap' }}>{p}</span>
-                            ))}
-                            {prereqs.length > 2 && (
-                              <span style={{ fontSize: 11, padding: '2px 7px', borderRadius: 999, background: dark ? '#1f2937' : '#f3f4f6', color: textSecondary, fontWeight: 600 }}>+{prereqs.length - 2}</span>
+                        <td style={{ padding: '14px 16px', verticalAlign: 'middle' }}>
+                          {prereqs.length === 0 ? (
+                            <span style={{ fontSize: 12, color: dark ? '#4b5563' : '#d1d5db', fontStyle: 'italic' }}>None</span>
+                          ) : (
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'nowrap' }}>
+                              {prereqs.slice(0, 2).map(p => (
+                                <span key={p} style={{ fontFamily: "'DM Mono','Fira Code',monospace", fontSize: 11, padding: '2px 7px', borderRadius: 6, background: dark ? '#1e3a5f' : '#eff6ff', color: dark ? '#93c5fd' : '#1d4ed8', border: `1px solid ${dark ? '#1d4ed8' : '#bfdbfe'}`, fontWeight: 500, whiteSpace: 'nowrap' }}>{p}</span>
+                              ))}
+                              {prereqs.length > 2 && (
+                                <span style={{ fontSize: 11, padding: '2px 7px', borderRadius: 999, background: dark ? '#1f2937' : '#f3f4f6', color: textSecondary, fontWeight: 600 }}>+{prereqs.length - 2}</span>
+                              )}
+                            </div>
+                          )}
+                        </td>
+                        
+                        <td style={{ padding: '14px 16px', verticalAlign: 'middle' }}>
+                          <div style={{ display: 'flex', gap: 5, alignItems: 'center' }}>
+
+                            {/* Details — everyone */}
+                            <Tooltip text="Knowledge Details">
+                              <button className="cl-icon-btn"
+                                onClick={() => setDrawerCourse(isDrawerOpen ? null : course)}
+                                style={{ background: isDrawerOpen ? '#1d4ed8' : (dark ? '#1e3a5f' : '#eff6ff'), color: isDrawerOpen ? '#fff' : (dark ? '#93c5fd' : '#1d4ed8'), border: `1px solid ${dark ? '#1d4ed8' : '#bfdbfe'}` }}>
+                                <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+                                  <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.4"/>
+                                  <path d="M7 6v4M7 4.5V5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+                                </svg>
+                              </button>
+                            </Tooltip>
+
+                            {/* Edit — admin & superadmin */}
+                            {canWrite && activeTab === 'active' && (
+                              <Tooltip text="Edit Course">
+                                <button className="cl-icon-btn"
+                                  onClick={() => setEditingCourse(course)}
+                                  style={{ background: dark ? '#1f2937' : '#f8fafc', color: dark ? '#9ca3af' : '#374151', border: `1px solid ${border}` }}>
+                                  <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+                                    <path d="M9.5 2.5l2 2-7 7H2.5v-2l7-7z" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+                                  </svg>
+                                </button>
+                              </Tooltip>
+                            )}
+
+                            {/* Archive — admin & superadmin (only on active tab) */}
+                            {canArchive && activeTab === 'active' && (
+                              <Tooltip text="Archive Course">
+                                <button className="cl-icon-btn"
+                                  onClick={() => setDisablingCourse(course)}
+                                  style={{ background: dark ? '#2d0a14' : '#fff1f2', color: dark ? '#fca5a5' : '#be123c', border: `1px solid ${dark ? '#7f1d1d' : '#fecdd3'}` }}>
+                                  <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+                                    <path d="M2 4h10M5 4V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1M6 7v3M8 7v3M3 4l.7 7a1 1 0 0 0 1 .9h4.6a1 1 0 0 0 1-.9L11 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+                                  </svg>
+                                </button>
+                              </Tooltip>
+                            )}
+
+                            {/* Restore — admin & superadmin (only on disabled tab) */}
+                            {canRestore && activeTab === 'disabled' && (
+                              <Tooltip text="Restore Course">
+                                <button className="cl-icon-btn"
+                                  onClick={() => handleEnable(course)}
+                                  style={{ background: dark ? '#0a2e1a' : '#f0fdf4', color: dark ? '#86efac' : '#15803d', border: `1px solid ${dark ? '#166534' : '#bbf7d0'}` }}>
+                                  <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+                                    <path d="M2 7a5 5 0 1 1 1.5 3.6M2 11V7h4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+                                  </svg>
+                                </button>
+                              </Tooltip>
                             )}
                           </div>
-                        )}
-                      </td>
-                      
-                      <td style={{ padding: '14px 16px', verticalAlign: 'middle' }}>
-                        <div style={{ display: 'flex', gap: 5, alignItems: 'center' }}>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
 
-                          {/* Details — everyone */}
-                          <Tooltip text="Knowledge Details">
-                            <button className="cl-icon-btn"
-                              onClick={() => setDrawerCourse(isDrawerOpen ? null : course)}
-                              style={{ background: isDrawerOpen ? '#1d4ed8' : (dark ? '#1e3a5f' : '#eff6ff'), color: isDrawerOpen ? '#fff' : (dark ? '#93c5fd' : '#1d4ed8'), border: `1px solid ${dark ? '#1d4ed8' : '#bfdbfe'}` }}>
-                              <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
-                                <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.4"/>
-                                <path d="M7 6v4M7 4.5V5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
-                              </svg>
-                            </button>
-                          </Tooltip>
-
-                          {/* Edit — admin & superadmin */}
-                          {canWrite && activeTab === 'active' && (
-                            <Tooltip text="Edit Course">
-                              <button className="cl-icon-btn"
-                                onClick={() => setEditingCourse(course)}
-                                style={{ background: dark ? '#1f2937' : '#f8fafc', color: dark ? '#9ca3af' : '#374151', border: `1px solid ${border}` }}>
-                                <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
-                                  <path d="M9.5 2.5l2 2-7 7H2.5v-2l7-7z" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
-                                </svg>
-                              </button>
-                            </Tooltip>
-                          )}
-
-                          {/* Archive — SUPERADMIN ONLY (only on active tab) */}
-                          {canArchive && activeTab === 'active' && (
-                            <Tooltip text="Archive Course">
-                              <button className="cl-icon-btn"
-                                onClick={() => setDisablingCourse(course)}
-                                style={{ background: dark ? '#2d0a14' : '#fff1f2', color: dark ? '#fca5a5' : '#be123c', border: `1px solid ${dark ? '#7f1d1d' : '#fecdd3'}` }}>
-                                <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
-                                  <path d="M2 4h10M5 4V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1M6 7v3M8 7v3M3 4l.7 7a1 1 0 0 0 1 .9h4.6a1 1 0 0 0 1-.9L11 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
-                                </svg>
-                              </button>
-                            </Tooltip>
-                          )}
-
-                          {/* Restore — ADMIN & SUPERADMIN (only on disabled tab) */}
-                          {canRestore && activeTab === 'disabled' && (
-                            <Tooltip text="Restore Course">
-                              <button className="cl-icon-btn"
-                                onClick={() => handleEnable(course)}
-                                style={{ background: dark ? '#0a2e1a' : '#f0fdf4', color: dark ? '#86efac' : '#15803d', border: `1px solid ${dark ? '#166534' : '#bbf7d0'}` }}>
-                                <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
-                                  <path d="M2 7a5 5 0 1 1 1.5 3.6M2 11V7h4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
-                                </svg>
-                              </button>
-                            </Tooltip>
-                          )}
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+            {/* Pagination controls */}
+            {totalPages > 1 && (
+              <div style={{
+                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                flexWrap: 'wrap', gap: 12, padding: '12px 20px',
+                borderTop: `1px solid ${border}`, background: filterBg,
+              }}>
+                <div style={{ fontSize: 13, color: textSecondary }}>
+                  Showing {startIndex + 1}–{Math.min(startIndex + itemsPerPage, filtered.length)} of {filtered.length} courses
+                </div>
+                <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+                  <button
+                    className="pagination-btn"
+                    onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                    disabled={currentPage === 1}
+                  >
+                    Previous
+                  </button>
+                  {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+                    let pageNum;
+                    if (totalPages <= 5) {
+                      pageNum = i + 1;
+                    } else if (currentPage <= 3) {
+                      pageNum = i + 1;
+                    } else if (currentPage >= totalPages - 2) {
+                      pageNum = totalPages - 4 + i;
+                    } else {
+                      pageNum = currentPage - 2 + i;
+                    }
+                    return (
+                      <button
+                        key={pageNum}
+                        className={`pagination-btn ${currentPage === pageNum ? 'active' : ''}`}
+                        onClick={() => setCurrentPage(pageNum)}
+                      >
+                        {pageNum}
+                      </button>
+                    );
+                  })}
+                  <button
+                    className="pagination-btn"
+                    onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+                    disabled={currentPage === totalPages}
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
         )}
       </div>
 
       {filtered.length > 0 && (
         <p className="anim-in" style={{ animationDelay: '0.15s', fontSize: 11, color: textSecondary, marginTop: 10, paddingLeft: 2 }}>
-          Showing {filtered.length} of {sourceList.length} course{sourceList.length !== 1 ? 's' : ''}
+          Showing {paginatedCourses.length} of {filtered.length} course{filtered.length !== 1 ? 's' : ''} on page {currentPage} of {totalPages}
         </p>
       )}
 
@@ -639,7 +728,7 @@ export default function CourseListPage() {
         </>
       )}
 
-      {/* Archive dialog only shown for superadmin */}
+      {/* Archive dialog */}
       {canArchive && (
         <SoftDisableConfirmDialog isOpen={disablingCourse !== null} onClose={() => setDisablingCourse(null)} onDisabled={handleCourseDisabled} courseId={disablingCourse?.id} courseCode={disablingCourse?.courseCode} />
       )}

--- a/src/pages/UserManagementPage.jsx
+++ b/src/pages/UserManagementPage.jsx
@@ -1,0 +1,663 @@
+import { useState, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+import { getAllUsers, promoteToAdmin, demoteFromAdmin } from "../services/userService";
+import { useAuth } from "../context/useAuth";
+import { Navigate } from "react-router-dom";
+
+function timeAgo(date) {
+  if (!date) return "Never";
+  const d   = date?.toDate ? date.toDate() : new Date(date);
+  const sec = Math.floor((Date.now() - d.getTime()) / 1000);
+  if (sec < 60)    return "Just now";
+  if (sec < 3600)  return `${Math.floor(sec / 60)}m ago`;
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`;
+  if (sec < 604800)return `${Math.floor(sec / 86400)}d ago`;
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+function Avatar({ user, size = 36 }) {
+  const [imgErr, setImgErr] = useState(false);
+  const initial = (user.displayName || user.email || "?")[0].toUpperCase();
+  if (user.photoURL && !imgErr) {
+    return (
+      <img src={user.photoURL} alt={user.displayName}
+        onError={() => setImgErr(true)}
+        style={{ width: size, height: size, borderRadius: "50%",
+          objectFit: "cover", flexShrink: 0 }} />
+    );
+  }
+  return (
+    <div style={{ width: size, height: size, borderRadius: "50%",
+      background: "linear-gradient(135deg,#1d4ed8,#3b82f6)",
+      display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+      <span style={{ color: "#fff", fontWeight: 700, fontSize: size * 0.38 }}>{initial}</span>
+    </div>
+  );
+}
+
+function ConfirmDialog({ isOpen, onClose, onConfirm, user, action, loading, dark }) {
+  if (!isOpen || !user) return null;
+  const isPromote = action === "promote";
+  return createPortal(
+    <div style={{ position: "fixed", inset: 0, zIndex: 60,
+      background: "rgba(15,23,42,0.6)", backdropFilter: "blur(3px)",
+      display: "flex", alignItems: "center", justifyContent: "center", padding: 16,
+      fontFamily: "'DM Sans', system-ui, sans-serif",
+      animation: "um-fadeIn 0.15s ease" }}>
+      <div style={{ background: dark ? "#1e293b" : "#fff", borderRadius: 16,
+        width: "100%", maxWidth: 420,
+        boxShadow: "0 24px 64px rgba(0,0,0,0.25)",
+        animation: "um-scaleIn 0.2s cubic-bezier(0.34,1.2,0.64,1)", overflow: "hidden" }}>
+
+        <div style={{ padding: "28px 28px 20px", display: "flex",
+          flexDirection: "column", alignItems: "center", gap: 12,
+          borderBottom: `1px solid ${dark ? "#334155" : "#f3f4f6"}` }}>
+          <div style={{ width: 52, height: 52, borderRadius: "50%",
+            background: isPromote ? (dark ? "#1e3a5f" : "#dbeafe") : (dark ? "#3b0f14" : "#fee2e2"),
+            display: "flex", alignItems: "center", justifyContent: "center" }}>
+            {isPromote ? (
+              <svg width="22" height="22" viewBox="0 0 22 22" fill="none">
+                <path d="M11 3v16M3 11h16" stroke="#1d4ed8" strokeWidth="2" strokeLinecap="round"/>
+              </svg>
+            ) : (
+              <svg width="22" height="22" viewBox="0 0 22 22" fill="none">
+                <path d="M5 11h12" stroke="#dc2626" strokeWidth="2" strokeLinecap="round"/>
+              </svg>
+            )}
+          </div>
+          <div style={{ textAlign: "center" }}>
+            <p style={{ margin: "0 0 5px", fontSize: 17, fontWeight: 700,
+              color: dark ? "#f1f5f9" : "#111827" }}>
+              {isPromote ? "Promote to Admin?" : "Remove Admin Access?"}
+            </p>
+            <p style={{ margin: 0, fontSize: 13, color: dark ? "#94a3b8" : "#6b7280", lineHeight: 1.5 }}>
+              {isPromote
+                ? `${user.displayName || user.email} will be able to add, edit, and manage courses.`
+                : `${user.displayName || user.email} will lose admin privileges and revert to a regular user.`}
+            </p>
+          </div>
+        </div>
+
+        <div style={{ padding: "16px 28px", borderBottom: `1px solid ${dark ? "#334155" : "#f3f4f6"}` }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px",
+            borderRadius: 10, background: dark ? "#0f172a" : "#f8fafc",
+            border: `1px solid ${dark ? "#334155" : "#e5e7eb"}` }}>
+            <Avatar user={user} size={32} />
+            <div style={{ minWidth: 0, flex: 1 }}>
+              <p style={{ margin: 0, fontSize: 13, fontWeight: 600,
+                color: dark ? "#f1f5f9" : "#111827", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {user.displayName || "—"}
+              </p>
+              <p style={{ margin: 0, fontSize: 11, color: dark ? "#64748b" : "#9ca3af",
+                overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {user.email}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div style={{ padding: "16px 28px", display: "flex", gap: 10, justifyContent: "flex-end" }}>
+          <button onClick={onClose} disabled={loading} style={{
+            padding: "9px 20px", borderRadius: 10,
+            border: `1px solid ${dark ? "#334155" : "#e5e7eb"}`,
+            background: dark ? "#1f2937" : "#f9fafb",
+            color: dark ? "#94a3b8" : "#374151",
+            fontSize: 13, fontWeight: 600, fontFamily: "inherit", cursor: "pointer" }}>
+            Cancel
+          </button>
+          <button onClick={onConfirm} disabled={loading} style={{
+            padding: "9px 20px", borderRadius: 10, border: "none",
+            background: isPromote
+              ? "linear-gradient(135deg,#1d4ed8,#2563eb)"
+              : "linear-gradient(135deg,#dc2626,#ef4444)",
+            color: "#fff", fontSize: 13, fontWeight: 600,
+            fontFamily: "inherit", cursor: "pointer", opacity: loading ? 0.6 : 1,
+            display: "flex", alignItems: "center", gap: 7 }}>
+            {loading && (
+              <span style={{ width: 12, height: 12, border: "2px solid rgba(255,255,255,0.3)",
+                borderTopColor: "#fff", borderRadius: "50%", display: "inline-block",
+                animation: "um-spin 0.7s linear infinite" }} />
+            )}
+            {loading ? "Saving…" : isPromote ? "Promote" : "Remove Admin"}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+// ── Main Page ──────────────────────────────────────────────────────────────
+export default function UserManagementPage() {
+  const { user: currentUser, role, authLoading } = useAuth();
+
+  // ── ALL hooks must come before any conditional return ──────────────────
+  const [users,         setUsers]         = useState([]);
+  const [loading,       setLoading]       = useState(true);
+  const [error,         setError]         = useState(null);
+  const [search,        setSearch]        = useState("");
+  const [filterRole,    setFilterRole]    = useState("all");
+  const [sortBy,        setSortBy]        = useState("lastLogin");
+  const [confirmDialog, setConfirmDialog] = useState({ open: false, user: null, action: null });
+  const [actionLoading, setActionLoading] = useState(false);
+  const [toastMsg,      setToastMsg]      = useState(null);
+  const [visible,       setVisible]       = useState(false);
+
+  const [dark, setDark] = useState(() =>
+    document.documentElement.classList.contains("dark")
+  );
+
+  useEffect(() => {
+    const obs = new MutationObserver(() =>
+      setDark(document.documentElement.classList.contains("dark"))
+    );
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    return () => obs.disconnect();
+  }, []);
+
+  const fetchUsers = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await getAllUsers();
+      setUsers(data);
+      setTimeout(() => setVisible(true), 50);
+    } catch (err) {
+      setError("Failed to load users. " + err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // ✅ This useEffect is now BEFORE the conditional return
+  useEffect(() => {
+    if (!authLoading && role === "admin") fetchUsers();
+  }, [authLoading, role, fetchUsers]);
+  // ──────────────────────────────────────────────────────────────────────
+
+  // Admin-only guard — safe to do AFTER all hooks
+  if (role && role !== "admin") return <Navigate to="/home" replace />;
+
+  const showToast = (msg) => {
+    setToastMsg(msg);
+    setTimeout(() => setToastMsg(null), 3000);
+  };
+
+  const handleAction = async () => {
+    if (!confirmDialog.user) return;
+    setActionLoading(true);
+    try {
+      if (confirmDialog.action === "promote") {
+        await promoteToAdmin(confirmDialog.user.email);
+        showToast(`${confirmDialog.user.displayName || confirmDialog.user.email} promoted to Admin.`);
+      } else {
+        await demoteFromAdmin(confirmDialog.user.email);
+        showToast(`${confirmDialog.user.displayName || confirmDialog.user.email} removed from Admin.`);
+      }
+      await fetchUsers();
+      setConfirmDialog({ open: false, user: null, action: null });
+    } catch (err) {
+      showToast("Error: " + err.message);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const filtered = users
+    .filter(u => {
+      const q = search.toLowerCase();
+      const matchSearch =
+        u.email?.toLowerCase().includes(q) ||
+        u.displayName?.toLowerCase().includes(q);
+      const matchRole =
+        filterRole === "all" ||
+        (filterRole === "admin" && u.role === "admin") ||
+        (filterRole === "user"  && u.role !== "admin");
+      return matchSearch && matchRole;
+    })
+    .sort((a, b) => {
+      if (sortBy === "name")  return (a.displayName || "").localeCompare(b.displayName || "");
+      if (sortBy === "email") return a.email.localeCompare(b.email);
+      if (sortBy === "role")  return (b.role === "admin" ? 1 : 0) - (a.role === "admin" ? 1 : 0);
+      const da  = a.lastLogin?.toDate?.() ?? new Date(a.lastLogin ?? 0);
+      const db_ = b.lastLogin?.toDate?.() ?? new Date(b.lastLogin ?? 0);
+      return db_ - da;
+    });
+
+  const adminCount = users.filter(u => u.role === "admin").length;
+  const userCount  = users.length - adminCount;
+
+  const bg        = dark ? "#0f172a" : "#f9fafb";
+  const cardBg    = dark ? "#111827" : "#fff";
+  const border    = dark ? "#1f2937" : "#e5e7eb";
+  const text      = dark ? "#f9fafb" : "#111827";
+  const textMuted = dark ? "#9ca3af" : "#6b7280";
+  const rowHover  = dark ? "#1a2234" : "#f8fafc";
+  const theadBg   = dark ? "#1a2234" : "#f8fafc";
+  const filterBg  = dark ? "#161f2e" : "#fafafa";
+
+    // Add this BEFORE the loading spinner return
+  if (authLoading) return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center",
+        minHeight: "60vh" }}>
+        <div style={{ textAlign: "center", fontFamily: "'DM Sans', system-ui, sans-serif" }}>
+        <div style={{ width: 36, height: 36,
+            border: "2px solid #dbeafe", borderTop: "2px solid #2563eb",
+            borderRadius: "50%", margin: "0 auto 12px",
+            animation: "um-spin 0.8s linear infinite" }} />
+        <style>{`@keyframes um-spin { to { transform: rotate(360deg); } }`}</style>
+        <p style={{ fontSize: 13, color: "#6b7280" }}>Verifying session…</p>
+        </div>
+    </div>
+  );
+
+  if (loading) return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center",
+      minHeight: "60vh", background: bg }}>
+      <div style={{ textAlign: "center", fontFamily: "'DM Sans', system-ui, sans-serif" }}>
+        <div style={{ width: 36, height: 36,
+          border: `2px solid ${dark ? "#1f2937" : "#dbeafe"}`,
+          borderTop: "2px solid #2563eb", borderRadius: "50%",
+          margin: "0 auto 12px", animation: "um-spin 0.8s linear infinite" }} />
+        <style>{`@keyframes um-spin { to { transform: rotate(360deg); } }`}</style>
+        <p style={{ fontSize: 13, color: textMuted }}>Loading users…</p>
+      </div>
+    </div>
+  );
+
+  return (
+    <div style={{ maxWidth: 1100, margin: "0 auto", padding: "28px 24px",
+      fontFamily: "'DM Sans', system-ui, sans-serif", background: bg, minHeight: "100vh" }}>
+      <style>{`
+        @keyframes um-fadeIn  { from{opacity:0} to{opacity:1} }
+        @keyframes um-scaleIn { from{opacity:0;transform:scale(0.95)} to{opacity:1;transform:scale(1)} }
+        @keyframes um-spin    { to{transform:rotate(360deg)} }
+        @keyframes um-slideUp { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
+        @keyframes um-toastIn { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:translateY(0)} }
+
+        .um-anim { animation: um-slideUp 0.35s ease both; }
+        .um-d1   { animation-delay: 0.03s; }
+        .um-d2   { animation-delay: 0.07s; }
+
+        .um-row { transition: background 0.12s; }
+        .um-row:hover { background: ${rowHover} !important; }
+
+        .um-sort-btn {
+          background: none; border: none; cursor: pointer;
+          font-family: inherit; font-size: 11px; font-weight: 700;
+          color: ${textMuted}; letter-spacing: .07em; text-transform: uppercase;
+          display: inline-flex; align-items: center; gap: 4px; padding: 0;
+          transition: color 0.15s;
+        }
+        .um-sort-btn:hover  { color: #2563eb; }
+        .um-sort-btn.active { color: #2563eb; }
+
+        .um-select {
+          appearance: none; -webkit-appearance: none;
+          padding: 7px 28px 7px 10px; border-radius: 9px;
+          border: 1px solid ${border};
+          background: ${cardBg} url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpath d='M2 3.5l3 3 3-3' stroke='%239ca3af' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E") no-repeat right 8px center;
+          color: ${text}; font-size: 13px; font-weight: 500;
+          font-family: inherit; cursor: pointer; outline: none;
+          transition: border-color 0.15s;
+        }
+        .um-select:focus { border-color: #2563eb; }
+
+        .um-action-btn {
+          padding: 5px 12px; border-radius: 7px; font-size: 11.5px;
+          font-weight: 600; font-family: inherit; cursor: pointer;
+          border: none; transition: all 0.15s; white-space: nowrap;
+        }
+        .um-action-btn:hover:not(:disabled) { transform: translateY(-1px); }
+
+        .um-search-wrap {
+          display: flex; align-items: center; gap: 8px;
+          background: ${cardBg}; border: 1px solid ${border};
+          border-radius: 10px; padding: 0 12px; height: 38px; width: 240px;
+          transition: border-color 0.2s, box-shadow 0.2s;
+        }
+        .um-search-wrap:focus-within {
+          border-color: #93c5fd;
+          box-shadow: 0 0 0 3px rgba(147,197,253,0.2);
+        }
+        .um-search-wrap input {
+          border: none; outline: none; font-size: 13px;
+          background: transparent; width: 100%;
+          font-family: inherit; color: ${text};
+        }
+      `}</style>
+
+      {/* Toast */}
+      {toastMsg && (
+        <div style={{ position: "fixed", bottom: 24, right: 24, zIndex: 9999,
+          background: dark ? "#1e293b" : "#111827", color: "#fff",
+          fontSize: 13, fontWeight: 500, padding: "10px 18px", borderRadius: 10,
+          boxShadow: "0 8px 24px rgba(0,0,0,0.25)", animation: "um-toastIn 0.25s ease",
+          display: "flex", alignItems: "center", gap: 8 }}>
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <circle cx="7" cy="7" r="5.5" fill="#22c55e"/>
+            <path d="M4.5 7l2 2 3-3" stroke="#fff" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+          {toastMsg}
+        </div>
+      )}
+
+      {/* Header */}
+      <div className="um-anim um-d1" style={{ display: "flex", alignItems: "flex-start",
+        justifyContent: "space-between", gap: 12, flexWrap: "wrap", marginBottom: 22 }}>
+        <div>
+          <p style={{ fontSize: 10, fontWeight: 700, letterSpacing: ".12em",
+            textTransform: "uppercase", color: "#2563eb", margin: "0 0 4px" }}>
+            Admin Portal
+          </p>
+          <h1 style={{ fontSize: 26, fontWeight: 700, color: text, margin: 0, letterSpacing: "-0.02em" }}>
+            User Management
+          </h1>
+          <p style={{ fontSize: 13, color: textMuted, margin: "5px 0 0" }}>
+            Manage student and admin access to the Knowledge Map.
+          </p>
+        </div>
+        <button onClick={fetchUsers} style={{ display: "inline-flex", alignItems: "center", gap: 6,
+          padding: "8px 16px", borderRadius: 10, border: `1px solid ${border}`,
+          background: cardBg, color: textMuted, fontSize: 13, fontWeight: 600,
+          fontFamily: "inherit", cursor: "pointer", transition: "all 0.15s" }}
+          onMouseEnter={e => e.currentTarget.style.borderColor = "#2563eb"}
+          onMouseLeave={e => e.currentTarget.style.borderColor = border}>
+          <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+            <path d="M13.5 8A5.5 5.5 0 1 1 10 3.07" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+            <polyline points="10,1 10,4 13,4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+          Refresh
+        </button>
+      </div>
+
+      {/* Stat cards */}
+      <div className="um-anim um-d1" style={{ display: "grid",
+        gridTemplateColumns: "repeat(3,1fr)", gap: 12, marginBottom: 22 }}>
+        {[
+          {
+            label: "Total Users", value: users.length,
+            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+              <circle cx="9" cy="6" r="3.5" stroke="#1d4ed8" strokeWidth="1.4"/>
+              <path d="M2.5 16c0-3.6 2.9-6 6.5-6s6.5 2.4 6.5 6" stroke="#1d4ed8" strokeWidth="1.4" strokeLinecap="round"/>
+            </svg>,
+            iconBg: dark ? "#1e3a5f" : "#eff6ff",
+          },
+          {
+            label: "Admins", value: adminCount,
+            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+              <path d="M9 2L11.5 7H16.5L12.5 10.3L14 15.5L9 12.5L4 15.5L5.5 10.3L1.5 7H6.5L9 2Z"
+                stroke="#d97706" strokeWidth="1.4" strokeLinejoin="round"/>
+            </svg>,
+            iconBg: dark ? "#2d1f07" : "#fffbeb",
+          },
+          {
+            label: "Students", value: userCount,
+            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+              <path d="M9 2l7 3.5-7 3.5-7-3.5L9 2Z" stroke="#15803d" strokeWidth="1.4" strokeLinejoin="round"/>
+              <path d="M16 5.5v5M4 9v4.5c0 1.5 2.2 3 5 3s5-1.5 5-3V9"
+                stroke="#15803d" strokeWidth="1.4" strokeLinecap="round"/>
+            </svg>,
+            iconBg: dark ? "#14301f" : "#f0fdf4",
+          },
+        ].map(s => (
+          <div key={s.label} style={{ background: cardBg, border: `1px solid ${border}`,
+            borderRadius: 12, padding: "16px 18px",
+            display: "flex", alignItems: "center", gap: 14 }}>
+            <div style={{ width: 40, height: 40, borderRadius: 10, background: s.iconBg,
+              display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+              {s.icon}
+            </div>
+            <div>
+              <p style={{ margin: 0, fontSize: 22, fontWeight: 700, color: text, lineHeight: 1 }}>
+                {s.value}
+              </p>
+              <p style={{ margin: "3px 0 0", fontSize: 12, color: textMuted, fontWeight: 500 }}>
+                {s.label}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Table card */}
+      <div className="um-anim um-d2" style={{ background: cardBg, border: `1px solid ${border}`,
+        borderRadius: 14, overflow: "hidden" }}>
+
+        {/* Toolbar */}
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between",
+          padding: "12px 16px", borderBottom: `1px solid ${border}`,
+          background: filterBg, flexWrap: "wrap", gap: 10 }}>
+          <div className="um-search-wrap">
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+              <circle cx="7" cy="7" r="5.5" stroke={textMuted} strokeWidth="1.4"/>
+              <path d="M11.5 11.5l2.5 2.5" stroke={textMuted} strokeWidth="1.4" strokeLinecap="round"/>
+            </svg>
+            <input type="text" placeholder="Search by name or email…"
+              value={search} onChange={e => setSearch(e.target.value)} />
+            {search && (
+              <button onClick={() => setSearch("")} style={{ background: "none", border: "none",
+                cursor: "pointer", color: textMuted, padding: 0, display: "flex" }}>
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                  <path d="M2 2l8 8M10 2l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                </svg>
+              </button>
+            )}
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+            <select className="um-select" value={filterRole} onChange={e => setFilterRole(e.target.value)}>
+              <option value="all">All Roles</option>
+              <option value="admin">Admins only</option>
+              <option value="user">Students only</option>
+            </select>
+            <select className="um-select" value={sortBy} onChange={e => setSortBy(e.target.value)}>
+              <option value="lastLogin">Last Login</option>
+              <option value="name">Name (A–Z)</option>
+              <option value="email">Email (A–Z)</option>
+              <option value="role">Role</option>
+            </select>
+            <span style={{ fontSize: 12, color: textMuted }}>
+              {filtered.length} user{filtered.length !== 1 ? "s" : ""}
+            </span>
+          </div>
+        </div>
+
+        {error && (
+          <div style={{ margin: 16, padding: "12px 16px", borderRadius: 10,
+            background: dark ? "rgba(220,38,38,0.1)" : "#fef2f2",
+            border: `1px solid ${dark ? "#7f1d1d" : "#fecaca"}`,
+            color: dark ? "#fca5a5" : "#b91c1c", fontSize: 13 }}>
+            {error}
+          </div>
+        )}
+
+        {!error && filtered.length === 0 ? (
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "center",
+            justifyContent: "center", padding: "64px 24px", color: textMuted }}>
+            <div style={{ width: 52, height: 52, borderRadius: 14,
+              background: dark ? "#1f2937" : "#f3f4f6",
+              display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 16 }}>
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+                <circle cx="9" cy="7" r="4" stroke={dark ? "#4b5563" : "#d1d5db"} strokeWidth="1.5"/>
+                <path d="M3 20c0-4 2.7-6 6-6s6 2 6 6"
+                  stroke={dark ? "#4b5563" : "#d1d5db"} strokeWidth="1.5" strokeLinecap="round"/>
+              </svg>
+            </div>
+            <p style={{ fontSize: 14, fontWeight: 600, color: textMuted, marginBottom: 4 }}>
+              {search || filterRole !== "all" ? "No users match your filters" : "No users found"}
+            </p>
+            <p style={{ fontSize: 12, color: dark ? "#4b5563" : "#9ca3af" }}>
+              {search || filterRole !== "all"
+                ? "Try clearing your search or filter"
+                : "Users appear here after they log in for the first time."}
+            </p>
+          </div>
+        ) : (
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr style={{ background: theadBg }}>
+                  {[
+                    { key: "name",      label: "User"       },
+                    { key: "role",      label: "Role"       },
+                    { key: "email",     label: "Email"      },
+                    { key: "lastLogin", label: "Last Login" },
+                    { key: null,        label: "Actions"    },
+                  ].map(col => (
+                    <th key={col.label} style={{ padding: "10px 16px", textAlign: "left",
+                      borderBottom: `1px solid ${border}`, whiteSpace: "nowrap" }}>
+                      {col.key ? (
+                        <button className={`um-sort-btn${sortBy === col.key ? " active" : ""}`}
+                          onClick={() => setSortBy(col.key)}>
+                          {col.label}
+                          <svg width="8" height="8" viewBox="0 0 8 8" fill="none"
+                            style={{ opacity: sortBy === col.key ? 1 : 0.35 }}>
+                            <path d="M1 3l3-2 3 2M1 5l3 2 3-2"
+                              stroke="currentColor" strokeWidth="1.3"
+                              strokeLinecap="round" strokeLinejoin="round"/>
+                          </svg>
+                        </button>
+                      ) : (
+                        <span style={{ fontSize: 11, fontWeight: 700, color: textMuted,
+                          letterSpacing: ".07em", textTransform: "uppercase" }}>
+                          {col.label}
+                        </span>
+                      )}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((u, idx) => {
+                  const isCurrentUser = u.email === currentUser?.email;
+                  const isAdmin       = u.role === "admin";
+                  return (
+                    <tr key={u.id} className="um-row" style={{
+                      borderBottom: `1px solid ${border}`,
+                      animation: "um-slideUp 0.3s ease both",
+                      animationDelay: `${idx * 0.025}s` }}>
+
+                      {/* User */}
+                      <td style={{ padding: "14px 16px", verticalAlign: "middle" }}>
+                        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                          <div style={{ position: "relative", flexShrink: 0 }}>
+                            <Avatar user={u} size={36} />
+                            {isAdmin && (
+                              <div style={{ position: "absolute", bottom: -2, right: -2,
+                                width: 14, height: 14, borderRadius: "50%", background: "#f59e0b",
+                                border: `2px solid ${cardBg}`, display: "flex",
+                                alignItems: "center", justifyContent: "center" }}>
+                                <svg width="7" height="7" viewBox="0 0 10 10" fill="none">
+                                  <path d="M5 1l1.5 3H10L7.5 6l1 3.5L5 8l-3.5 1.5 1-3.5L0 4h3.5L5 1Z" fill="#fff"/>
+                                </svg>
+                              </div>
+                            )}
+                          </div>
+                          <div style={{ minWidth: 0 }}>
+                            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                              <span style={{ fontSize: 14, fontWeight: 600, color: text,
+                                whiteSpace: "nowrap", overflow: "hidden",
+                                textOverflow: "ellipsis", maxWidth: 180 }}>
+                                {u.displayName || "—"}
+                              </span>
+                              {isCurrentUser && (
+                                <span style={{ fontSize: 9, fontWeight: 700, padding: "1px 6px",
+                                  borderRadius: 999,
+                                  background: dark ? "#1e3a5f" : "#dbeafe",
+                                  color: dark ? "#93c5fd" : "#1d4ed8",
+                                  letterSpacing: ".05em", textTransform: "uppercase", whiteSpace: "nowrap" }}>
+                                  You
+                                </span>
+                              )}
+                            </div>
+                            <p style={{ margin: 0, fontSize: 11, color: textMuted,
+                              fontFamily: "'DM Mono','Fira Code',monospace" }}>
+                              {u.uid?.slice(0, 10)}…
+                            </p>
+                          </div>
+                        </div>
+                      </td>
+
+                      {/* Role */}
+                      <td style={{ padding: "14px 16px", verticalAlign: "middle" }}>
+                        <span style={{ display: "inline-flex", alignItems: "center", gap: 5,
+                          padding: "4px 10px", borderRadius: 999, fontSize: 11.5, fontWeight: 700,
+                          background: isAdmin
+                            ? (dark ? "#2d1f07" : "#fffbeb") : (dark ? "#1f2937" : "#f3f4f6"),
+                          color: isAdmin
+                            ? (dark ? "#fcd34d" : "#b45309") : (dark ? "#6b7280" : "#6b7280"),
+                          border: `1px solid ${isAdmin
+                            ? (dark ? "#854d0e" : "#fde68a") : (dark ? "#374151" : "#e5e7eb")}` }}>
+                          {isAdmin ? "⭐ Admin" : "👤 Student"}
+                        </span>
+                      </td>
+
+                      {/* Email */}
+                      <td style={{ padding: "14px 16px", verticalAlign: "middle" }}>
+                        <span style={{ fontSize: 13, color: textMuted,
+                          fontFamily: "'DM Mono','Fira Code',monospace" }}>
+                          {u.email}
+                        </span>
+                      </td>
+
+                      {/* Last Login */}
+                      <td style={{ padding: "14px 16px", verticalAlign: "middle" }}>
+                        <span style={{ fontSize: 12.5, color: textMuted }}>
+                          {timeAgo(u.lastLogin)}
+                        </span>
+                      </td>
+
+                      {/* Actions */}
+                      <td style={{ padding: "14px 16px", verticalAlign: "middle" }}>
+                        {isCurrentUser ? (
+                          <span style={{ fontSize: 11.5,
+                            color: dark ? "#475569" : "#d1d5db", fontStyle: "italic" }}>
+                            (current session)
+                          </span>
+                        ) : isAdmin ? (
+                          <button className="um-action-btn"
+                            onClick={() => setConfirmDialog({ open: true, user: u, action: "demote" })}
+                            style={{ background: dark ? "#2d0a14" : "#fff1f2",
+                              color: dark ? "#fca5a5" : "#be123c",
+                              border: `1px solid ${dark ? "#7f1d1d" : "#fecdd3"}` }}>
+                            Remove Admin
+                          </button>
+                        ) : (
+                          <button className="um-action-btn"
+                            onClick={() => setConfirmDialog({ open: true, user: u, action: "promote" })}
+                            style={{ background: dark ? "#1e3a5f" : "#eff6ff",
+                              color: dark ? "#93c5fd" : "#1d4ed8",
+                              border: `1px solid ${dark ? "#1d4ed8" : "#bfdbfe"}` }}>
+                            Make Admin
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {filtered.length > 0 && (
+          <div style={{ padding: "10px 16px", borderTop: `1px solid ${border}`, background: filterBg }}>
+            <p style={{ margin: 0, fontSize: 11, color: textMuted }}>
+              Showing {filtered.length} of {users.length} registered user{users.length !== 1 ? "s" : ""}
+            </p>
+          </div>
+        )}
+      </div>
+
+      <ConfirmDialog
+        isOpen={confirmDialog.open}
+        onClose={() => setConfirmDialog({ open: false, user: null, action: null })}
+        onConfirm={handleAction}
+        user={confirmDialog.user}
+        action={confirmDialog.action}
+        loading={actionLoading}
+        dark={dark}
+      />
+    </div>
+  );
+}

--- a/src/pages/UserManagementPage.jsx
+++ b/src/pages/UserManagementPage.jsx
@@ -1,17 +1,27 @@
 import { useState, useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
-import { getAllUsers, promoteToAdmin, demoteFromAdmin } from "../services/userService";
+import {
+  getAllUsers,
+  promoteToAdmin,
+  demoteFromAdmin,
+  blockUser,
+  unblockUser,
+  deleteUser,
+  addAdminByEmail,
+  getUserRole,        // <-- NEW: to check superadmin status
+} from "../services/userService";
 import { useAuth } from "../context/useAuth";
 import { Navigate } from "react-router-dom";
 
+// ── Helpers ───────────────────────────────────────────────────────────────
 function timeAgo(date) {
   if (!date) return "Never";
   const d   = date?.toDate ? date.toDate() : new Date(date);
   const sec = Math.floor((Date.now() - d.getTime()) / 1000);
-  if (sec < 60)    return "Just now";
-  if (sec < 3600)  return `${Math.floor(sec / 60)}m ago`;
-  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`;
-  if (sec < 604800)return `${Math.floor(sec / 86400)}d ago`;
+  if (sec < 60)     return "Just now";
+  if (sec < 3600)   return `${Math.floor(sec / 60)}m ago`;
+  if (sec < 86400)  return `${Math.floor(sec / 3600)}h ago`;
+  if (sec < 604800) return `${Math.floor(sec / 86400)}d ago`;
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 }
 
@@ -35,57 +45,54 @@ function Avatar({ user, size = 36 }) {
   );
 }
 
+// ── Confirm Dialog ────────────────────────────────────────────────────────
 function ConfirmDialog({ isOpen, onClose, onConfirm, user, action, loading, dark }) {
   if (!isOpen || !user) return null;
-  const isPromote = action === "promote";
+
+  const configs = {
+    promote: { color: "#1d4ed8", bg: dark ? "#1e3a5f" : "#dbeafe", label: "Promote to Admin",  icon: "⭐", desc: `${user.displayName || user.email} will gain admin privileges.` },
+    demote:  { color: "#dc2626", bg: dark ? "#3b0f14" : "#fee2e2", label: "Remove Admin",       icon: "👤", desc: `${user.displayName || user.email} will revert to a regular user.` },
+    block:   { color: "#f59e0b", bg: dark ? "#2d1f07" : "#fffbeb", label: "Block User",         icon: "🚫", desc: `${user.displayName || user.email} will be blocked from signing in.` },
+    unblock: { color: "#22c55e", bg: dark ? "#14301f" : "#f0fdf4", label: "Unblock User",       icon: "✅", desc: `${user.displayName || user.email} will be allowed to sign in again.` },
+    delete:  { color: "#dc2626", bg: dark ? "#3b0f14" : "#fee2e2", label: "Delete User",        icon: "🗑️", desc: `This will permanently delete ${user.email}. This cannot be undone.` },
+  };
+  const cfg = configs[action] || configs.promote;
+
   return createPortal(
     <div style={{ position: "fixed", inset: 0, zIndex: 60,
-      background: "rgba(15,23,42,0.6)", backdropFilter: "blur(3px)",
+      background: "rgba(15,23,42,0.65)", backdropFilter: "blur(4px)",
       display: "flex", alignItems: "center", justifyContent: "center", padding: 16,
-      fontFamily: "'DM Sans', system-ui, sans-serif",
-      animation: "um-fadeIn 0.15s ease" }}>
+      fontFamily: "'DM Sans', system-ui, sans-serif", animation: "um-fadeIn 0.15s ease" }}>
       <div style={{ background: dark ? "#1e293b" : "#fff", borderRadius: 16,
-        width: "100%", maxWidth: 420,
-        boxShadow: "0 24px 64px rgba(0,0,0,0.25)",
+        width: "100%", maxWidth: 420, boxShadow: "0 24px 64px rgba(0,0,0,0.25)",
         animation: "um-scaleIn 0.2s cubic-bezier(0.34,1.2,0.64,1)", overflow: "hidden" }}>
 
         <div style={{ padding: "28px 28px 20px", display: "flex",
           flexDirection: "column", alignItems: "center", gap: 12,
           borderBottom: `1px solid ${dark ? "#334155" : "#f3f4f6"}` }}>
           <div style={{ width: 52, height: 52, borderRadius: "50%",
-            background: isPromote ? (dark ? "#1e3a5f" : "#dbeafe") : (dark ? "#3b0f14" : "#fee2e2"),
-            display: "flex", alignItems: "center", justifyContent: "center" }}>
-            {isPromote ? (
-              <svg width="22" height="22" viewBox="0 0 22 22" fill="none">
-                <path d="M11 3v16M3 11h16" stroke="#1d4ed8" strokeWidth="2" strokeLinecap="round"/>
-              </svg>
-            ) : (
-              <svg width="22" height="22" viewBox="0 0 22 22" fill="none">
-                <path d="M5 11h12" stroke="#dc2626" strokeWidth="2" strokeLinecap="round"/>
-              </svg>
-            )}
+            background: cfg.bg, display: "flex", alignItems: "center",
+            justifyContent: "center", fontSize: 22 }}>
+            {cfg.icon}
           </div>
           <div style={{ textAlign: "center" }}>
             <p style={{ margin: "0 0 5px", fontSize: 17, fontWeight: 700,
-              color: dark ? "#f1f5f9" : "#111827" }}>
-              {isPromote ? "Promote to Admin?" : "Remove Admin Access?"}
-            </p>
+              color: dark ? "#f1f5f9" : "#111827" }}>{cfg.label}?</p>
             <p style={{ margin: 0, fontSize: 13, color: dark ? "#94a3b8" : "#6b7280", lineHeight: 1.5 }}>
-              {isPromote
-                ? `${user.displayName || user.email} will be able to add, edit, and manage courses.`
-                : `${user.displayName || user.email} will lose admin privileges and revert to a regular user.`}
+              {cfg.desc}
             </p>
           </div>
         </div>
 
-        <div style={{ padding: "16px 28px", borderBottom: `1px solid ${dark ? "#334155" : "#f3f4f6"}` }}>
+        <div style={{ padding: "14px 28px", borderBottom: `1px solid ${dark ? "#334155" : "#f3f4f6"}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px",
             borderRadius: 10, background: dark ? "#0f172a" : "#f8fafc",
             border: `1px solid ${dark ? "#334155" : "#e5e7eb"}` }}>
             <Avatar user={user} size={32} />
             <div style={{ minWidth: 0, flex: 1 }}>
               <p style={{ margin: 0, fontSize: 13, fontWeight: 600,
-                color: dark ? "#f1f5f9" : "#111827", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                color: dark ? "#f1f5f9" : "#111827",
+                overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                 {user.displayName || "—"}
               </p>
               <p style={{ margin: 0, fontSize: 11, color: dark ? "#64748b" : "#9ca3af",
@@ -107,18 +114,16 @@ function ConfirmDialog({ isOpen, onClose, onConfirm, user, action, loading, dark
           </button>
           <button onClick={onConfirm} disabled={loading} style={{
             padding: "9px 20px", borderRadius: 10, border: "none",
-            background: isPromote
-              ? "linear-gradient(135deg,#1d4ed8,#2563eb)"
-              : "linear-gradient(135deg,#dc2626,#ef4444)",
-            color: "#fff", fontSize: 13, fontWeight: 600,
+            background: cfg.color, color: "#fff", fontSize: 13, fontWeight: 600,
             fontFamily: "inherit", cursor: "pointer", opacity: loading ? 0.6 : 1,
             display: "flex", alignItems: "center", gap: 7 }}>
             {loading && (
-              <span style={{ width: 12, height: 12, border: "2px solid rgba(255,255,255,0.3)",
-                borderTopColor: "#fff", borderRadius: "50%", display: "inline-block",
+              <span style={{ width: 12, height: 12,
+                border: "2px solid rgba(255,255,255,0.3)", borderTopColor: "#fff",
+                borderRadius: "50%", display: "inline-block",
                 animation: "um-spin 0.7s linear infinite" }} />
             )}
-            {loading ? "Saving…" : isPromote ? "Promote" : "Remove Admin"}
+            {loading ? "Saving…" : cfg.label}
           </button>
         </div>
       </div>
@@ -127,11 +132,129 @@ function ConfirmDialog({ isOpen, onClose, onConfirm, user, action, loading, dark
   );
 }
 
-// ── Main Page ──────────────────────────────────────────────────────────────
+// ── Add Admin Modal ───────────────────────────────────────────────────────
+function AddAdminModal({ isOpen, onClose, onAdded, dark }) {
+  const [email,   setEmail]   = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error,   setError]   = useState("");
+
+  const handleSubmit = async () => {
+    const trimmed = email.trim().toLowerCase();
+    if (!trimmed)                          { setError("Email is required."); return; }
+    if (!trimmed.endsWith("@neu.edu.ph")) { setError("Only @neu.edu.ph emails allowed."); return; }
+
+    setLoading(true);
+    setError("");
+
+    try {
+      // Check if the user already exists and is a superadmin
+      const role = await getUserRole(trimmed);
+      if (role === "superadmin") {
+        setError("This user is a Superadmin and cannot be changed via this action.");
+        setLoading(false);
+        return;
+      }
+      await addAdminByEmail(trimmed);
+      onAdded(trimmed);
+      setEmail("");
+      onClose();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div style={{ position: "fixed", inset: 0, zIndex: 60,
+      background: "rgba(15,23,42,0.65)", backdropFilter: "blur(4px)",
+      display: "flex", alignItems: "center", justifyContent: "center", padding: 16,
+      fontFamily: "'DM Sans', system-ui, sans-serif", animation: "um-fadeIn 0.15s ease" }}>
+      <div style={{ background: dark ? "#1e293b" : "#fff", borderRadius: 16,
+        width: "100%", maxWidth: 400, boxShadow: "0 24px 64px rgba(0,0,0,0.25)",
+        animation: "um-scaleIn 0.2s cubic-bezier(0.34,1.2,0.64,1)" }}>
+
+        <div style={{ padding: "20px 24px 16px",
+          borderBottom: `1px solid ${dark ? "#334155" : "#f3f4f6"}`,
+          display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <div>
+            <p style={{ margin: 0, fontSize: 10, fontWeight: 700, letterSpacing: ".1em",
+              textTransform: "uppercase", color: dark ? "#475569" : "#9ca3af" }}>Superadmin</p>
+            <h3 style={{ margin: "3px 0 0", fontSize: 16, fontWeight: 700,
+              color: dark ? "#f1f5f9" : "#111827" }}>Add Admin by Email</h3>
+          </div>
+          <button onClick={onClose} style={{ background: "none", border: "none",
+            color: dark ? "#475569" : "#9ca3af", fontSize: 22, cursor: "pointer",
+            padding: 0, lineHeight: 1 }}>×</button>
+        </div>
+
+        <div style={{ padding: "20px 24px 24px" }}>
+          <p style={{ margin: "0 0 14px", fontSize: 13,
+            color: dark ? "#94a3b8" : "#6b7280", lineHeight: 1.5 }}>
+            Enter a <strong style={{ color: dark ? "#f1f5f9" : "#111827" }}>@neu.edu.ph</strong> email.
+            If the user hasn't logged in yet, they'll have admin access when they do.
+          </p>
+
+          {error && (
+            <div style={{ background: dark ? "rgba(220,38,38,0.1)" : "#fef2f2",
+              border: `1px solid ${dark ? "#7f1d1d" : "#fecaca"}`,
+              color: dark ? "#fca5a5" : "#b91c1c",
+              borderRadius: 8, padding: "9px 12px", fontSize: 12, marginBottom: 12 }}>
+              {error}
+            </div>
+          )}
+
+          <input type="email" value={email}
+            onChange={e => setEmail(e.target.value)}
+            onKeyDown={e => e.key === "Enter" && handleSubmit()}
+            placeholder="e.g. juan.delacruz@neu.edu.ph"
+            style={{ width: "100%", height: 40, padding: "0 12px",
+              borderRadius: 10, fontSize: 13, fontFamily: "inherit",
+              border: `1.5px solid ${dark ? "#334155" : "#e5e7eb"}`,
+              background: dark ? "#0f172a" : "#f9fafb",
+              color: dark ? "#f1f5f9" : "#111827",
+              outline: "none", boxSizing: "border-box", transition: "border-color 0.15s" }}
+            onFocus={e  => e.target.style.borderColor = "#2563eb"}
+            onBlur={e   => e.target.style.borderColor = dark ? "#334155" : "#e5e7eb"}
+          />
+
+          <div style={{ display: "flex", gap: 10, justifyContent: "flex-end", marginTop: 16 }}>
+            <button onClick={onClose} style={{ padding: "9px 18px", borderRadius: 10,
+              border: `1px solid ${dark ? "#334155" : "#e5e7eb"}`,
+              background: dark ? "#1f2937" : "#f9fafb",
+              color: dark ? "#94a3b8" : "#374151",
+              fontSize: 13, fontWeight: 600, fontFamily: "inherit", cursor: "pointer" }}>
+              Cancel
+            </button>
+            <button onClick={handleSubmit} disabled={loading} style={{
+              padding: "9px 20px", borderRadius: 10, border: "none",
+              background: "linear-gradient(135deg,#1d4ed8,#2563eb)",
+              color: "#fff", fontSize: 13, fontWeight: 600, fontFamily: "inherit",
+              cursor: "pointer", opacity: loading ? 0.6 : 1,
+              display: "flex", alignItems: "center", gap: 7 }}>
+              {loading && (
+                <span style={{ width: 12, height: 12,
+                  border: "2px solid rgba(255,255,255,0.3)", borderTopColor: "#fff",
+                  borderRadius: "50%", display: "inline-block",
+                  animation: "um-spin 0.7s linear infinite" }} />
+              )}
+              {loading ? "Adding…" : "Add Admin"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+// ── Main Page ─────────────────────────────────────────────────────────────
 export default function UserManagementPage() {
   const { user: currentUser, role, authLoading } = useAuth();
 
-  // ── ALL hooks must come before any conditional return ──────────────────
+  // ── All hooks first — no exceptions ───────────────────────────────────
   const [users,         setUsers]         = useState([]);
   const [loading,       setLoading]       = useState(true);
   const [error,         setError]         = useState(null);
@@ -141,7 +264,8 @@ export default function UserManagementPage() {
   const [confirmDialog, setConfirmDialog] = useState({ open: false, user: null, action: null });
   const [actionLoading, setActionLoading] = useState(false);
   const [toastMsg,      setToastMsg]      = useState(null);
-  const [visible,       setVisible]       = useState(false);
+  const [toastType,     setToastType]     = useState("success");
+  const [addAdminOpen,  setAddAdminOpen]  = useState(false);
 
   const [dark, setDark] = useState(() =>
     document.documentElement.classList.contains("dark")
@@ -155,13 +279,15 @@ export default function UserManagementPage() {
     return () => obs.disconnect();
   }, []);
 
+  const isSA        = role === "superadmin";
+  const isAdminOrSA = role === "admin" || role === "superadmin";
+
   const fetchUsers = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
       const data = await getAllUsers();
       setUsers(data);
-      setTimeout(() => setVisible(true), 50);
     } catch (err) {
       setError("Failed to load users. " + err.message);
     } finally {
@@ -169,40 +295,109 @@ export default function UserManagementPage() {
     }
   }, []);
 
-  // ✅ This useEffect is now BEFORE the conditional return
   useEffect(() => {
-    if (!authLoading && role === "admin") fetchUsers();
-  }, [authLoading, role, fetchUsers]);
-  // ──────────────────────────────────────────────────────────────────────
+    if (!authLoading && isAdminOrSA) fetchUsers();
+  }, [authLoading, isAdminOrSA, fetchUsers]);
 
-  // Admin-only guard — safe to do AFTER all hooks
-  if (role && role !== "admin") return <Navigate to="/home" replace />;
+  // ── Guard — after all hooks ────────────────────────────────────────────
+  if (authLoading) return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: "60vh" }}>
+      <div style={{ textAlign: "center", fontFamily: "'DM Sans', system-ui, sans-serif" }}>
+        <div style={{ width: 36, height: 36, border: "2px solid #dbeafe",
+          borderTop: "2px solid #2563eb", borderRadius: "50%",
+          margin: "0 auto 12px", animation: "um-spin 0.8s linear infinite" }} />
+        <style>{`@keyframes um-spin { to { transform: rotate(360deg); } }`}</style>
+        <p style={{ fontSize: 13, color: "#6b7280" }}>Verifying session…</p>
+      </div>
+    </div>
+  );
 
-  const showToast = (msg) => {
-    setToastMsg(msg);
-    setTimeout(() => setToastMsg(null), 3000);
+  if (role && !isAdminOrSA) return <Navigate to="/home" replace />;
+
+  if (loading) return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center",
+      minHeight: "60vh", background: dark ? "#0f172a" : "#f9fafb" }}>
+      <div style={{ textAlign: "center", fontFamily: "'DM Sans', system-ui, sans-serif" }}>
+        <div style={{ width: 36, height: 36,
+          border: `2px solid ${dark ? "#1f2937" : "#dbeafe"}`,
+          borderTop: "2px solid #2563eb", borderRadius: "50%",
+          margin: "0 auto 12px", animation: "um-spin 0.8s linear infinite" }} />
+        <style>{`@keyframes um-spin { to { transform: rotate(360deg); } }`}</style>
+        <p style={{ fontSize: 13, color: dark ? "#9ca3af" : "#6b7280" }}>Loading users…</p>
+      </div>
+    </div>
+  );
+
+  // ── Helpers ────────────────────────────────────────────────────────────
+  const showToast = (msg, type = "success") => {
+    setToastMsg(msg); setToastType(type);
+    setTimeout(() => setToastMsg(null), 3500);
+  };
+
+  const openConfirm = (user, action) =>
+    setConfirmDialog({ open: true, user, action });
+
+  // ── What can the current user do to a target? ──────────────────────────
+  // Rules:
+  //   superadmin → can promote/demote/block/unblock/delete anyone EXCEPT other superadmins
+  //   admin      → can block/unblock/delete regular students ONLY
+  //   neither can touch themselves
+  const getAvailableActions = (target) => {
+    if (!target) return {};
+    const isMe          = target.email === currentUser?.email;
+    const isTargetSA    = target.role === "superadmin";
+    if (isMe || isTargetSA) return {};          // protected: yourself & superadmins
+
+    const targetIsAdmin   = target.role === "admin";
+    const targetIsUser    = target.role === "user";
+    const targetBlocked   = !!target.isBlocked;
+
+    if (isSA) {
+      return {
+        canPromote:  targetIsUser,              // only promote students → admin
+        canDemote:   targetIsAdmin,             // demote admin → student
+        canBlock:    !targetBlocked,
+        canUnblock:  targetBlocked,
+        canDelete:   true,                      // superadmin can delete anyone (except SAs)
+      };
+    }
+
+    if (role === "admin") {
+      return {
+        canPromote:  false,                     // admins cannot promote
+        canDemote:   false,                     // admins cannot demote
+        canBlock:    targetIsUser && !targetBlocked,
+        canUnblock:  targetIsUser && targetBlocked,
+        canDelete:   targetIsUser,              // admins can delete regular students
+      };
+    }
+
+    return {};
   };
 
   const handleAction = async () => {
     if (!confirmDialog.user) return;
     setActionLoading(true);
+    const { email } = confirmDialog.user;
     try {
-      if (confirmDialog.action === "promote") {
-        await promoteToAdmin(confirmDialog.user.email);
-        showToast(`${confirmDialog.user.displayName || confirmDialog.user.email} promoted to Admin.`);
-      } else {
-        await demoteFromAdmin(confirmDialog.user.email);
-        showToast(`${confirmDialog.user.displayName || confirmDialog.user.email} removed from Admin.`);
+      switch (confirmDialog.action) {
+        case "promote":  await promoteToAdmin(email);  showToast(`${email} promoted to Admin.`); break;
+        case "demote":   await demoteFromAdmin(email); showToast(`${email} removed from Admin.`); break;
+        case "block":    await blockUser(email);       showToast(`${email} has been blocked.`,   "warn"); break;
+        case "unblock":  await unblockUser(email);     showToast(`${email} has been unblocked.`); break;
+        case "delete":   await deleteUser(email);      showToast(`${email} has been deleted.`,   "warn"); break;
+        default: break;
       }
       await fetchUsers();
       setConfirmDialog({ open: false, user: null, action: null });
     } catch (err) {
-      showToast("Error: " + err.message);
+      showToast("Error: " + err.message, "error");
     } finally {
       setActionLoading(false);
     }
   };
 
+  // ── Derived data ───────────────────────────────────────────────────────
   const filtered = users
     .filter(u => {
       const q = search.toLowerCase();
@@ -210,23 +405,31 @@ export default function UserManagementPage() {
         u.email?.toLowerCase().includes(q) ||
         u.displayName?.toLowerCase().includes(q);
       const matchRole =
-        filterRole === "all" ||
-        (filterRole === "admin" && u.role === "admin") ||
-        (filterRole === "user"  && u.role !== "admin");
+        filterRole === "all"        ? true :
+        filterRole === "superadmin" ? u.role === "superadmin" :
+        filterRole === "admin"      ? u.role === "admin" :
+        filterRole === "blocked"    ? u.isBlocked === true :
+                                      u.role === "user";
       return matchSearch && matchRole;
     })
     .sort((a, b) => {
       if (sortBy === "name")  return (a.displayName || "").localeCompare(b.displayName || "");
       if (sortBy === "email") return a.email.localeCompare(b.email);
-      if (sortBy === "role")  return (b.role === "admin" ? 1 : 0) - (a.role === "admin" ? 1 : 0);
+      if (sortBy === "role")  {
+        const order = { superadmin: 0, admin: 1, user: 2 };
+        return (order[a.role] ?? 3) - (order[b.role] ?? 3);
+      }
       const da  = a.lastLogin?.toDate?.() ?? new Date(a.lastLogin ?? 0);
       const db_ = b.lastLogin?.toDate?.() ?? new Date(b.lastLogin ?? 0);
       return db_ - da;
     });
 
-  const adminCount = users.filter(u => u.role === "admin").length;
-  const userCount  = users.length - adminCount;
+  const saCount      = users.filter(u => u.role === "superadmin").length;
+  const adminCount   = users.filter(u => u.role === "admin").length;
+  const studentCount = users.filter(u => u.role === "user").length;
+  const blockedCount = users.filter(u => u.isBlocked).length;
 
+  // ── Theme ──────────────────────────────────────────────────────────────
   const bg        = dark ? "#0f172a" : "#f9fafb";
   const cardBg    = dark ? "#111827" : "#fff";
   const border    = dark ? "#1f2937" : "#e5e7eb";
@@ -236,37 +439,27 @@ export default function UserManagementPage() {
   const theadBg   = dark ? "#1a2234" : "#f8fafc";
   const filterBg  = dark ? "#161f2e" : "#fafafa";
 
-    // Add this BEFORE the loading spinner return
-  if (authLoading) return (
-    <div style={{ display: "flex", alignItems: "center", justifyContent: "center",
-        minHeight: "60vh" }}>
-        <div style={{ textAlign: "center", fontFamily: "'DM Sans', system-ui, sans-serif" }}>
-        <div style={{ width: 36, height: 36,
-            border: "2px solid #dbeafe", borderTop: "2px solid #2563eb",
-            borderRadius: "50%", margin: "0 auto 12px",
-            animation: "um-spin 0.8s linear infinite" }} />
-        <style>{`@keyframes um-spin { to { transform: rotate(360deg); } }`}</style>
-        <p style={{ fontSize: 13, color: "#6b7280" }}>Verifying session…</p>
-        </div>
-    </div>
-  );
-
-  if (loading) return (
-    <div style={{ display: "flex", alignItems: "center", justifyContent: "center",
-      minHeight: "60vh", background: bg }}>
-      <div style={{ textAlign: "center", fontFamily: "'DM Sans', system-ui, sans-serif" }}>
-        <div style={{ width: 36, height: 36,
-          border: `2px solid ${dark ? "#1f2937" : "#dbeafe"}`,
-          borderTop: "2px solid #2563eb", borderRadius: "50%",
-          margin: "0 auto 12px", animation: "um-spin 0.8s linear infinite" }} />
-        <style>{`@keyframes um-spin { to { transform: rotate(360deg); } }`}</style>
-        <p style={{ fontSize: 13, color: textMuted }}>Loading users…</p>
-      </div>
-    </div>
-  );
+  const roleBadge = (u) => {
+    if (u.role === "superadmin") return {
+      bg: dark ? "#1e1040" : "#f5f3ff", color: dark ? "#c084fc" : "#7c3aed",
+      border: dark ? "#6d28d9" : "#ddd6fe", label: "⚡ Superadmin",
+    };
+    if (u.role === "admin") return {
+      bg: dark ? "#2d1f07" : "#fffbeb", color: dark ? "#fcd34d" : "#b45309",
+      border: dark ? "#854d0e" : "#fde68a", label: "⭐ Admin",
+    };
+    if (u.isBlocked) return {
+      bg: dark ? "#3b0f14" : "#fff1f2", color: dark ? "#fca5a5" : "#be123c",
+      border: dark ? "#7f1d1d" : "#fecdd3", label: "🚫 Blocked",
+    };
+    return {
+      bg: dark ? "#1f2937" : "#f3f4f6", color: dark ? "#6b7280" : "#6b7280",
+      border: dark ? "#374151" : "#e5e7eb", label: "👤 Student",
+    };
+  };
 
   return (
-    <div style={{ maxWidth: 1100, margin: "0 auto", padding: "28px 24px",
+    <div style={{ maxWidth: 1200, margin: "0 auto", padding: "28px 24px",
       fontFamily: "'DM Sans', system-ui, sans-serif", background: bg, minHeight: "100vh" }}>
       <style>{`
         @keyframes um-fadeIn  { from{opacity:0} to{opacity:1} }
@@ -274,24 +467,19 @@ export default function UserManagementPage() {
         @keyframes um-spin    { to{transform:rotate(360deg)} }
         @keyframes um-slideUp { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
         @keyframes um-toastIn { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:translateY(0)} }
-
         .um-anim { animation: um-slideUp 0.35s ease both; }
         .um-d1   { animation-delay: 0.03s; }
         .um-d2   { animation-delay: 0.07s; }
-
-        .um-row { transition: background 0.12s; }
+        .um-row  { transition: background 0.12s; }
         .um-row:hover { background: ${rowHover} !important; }
-
-        .um-sort-btn {
-          background: none; border: none; cursor: pointer;
-          font-family: inherit; font-size: 11px; font-weight: 700;
-          color: ${textMuted}; letter-spacing: .07em; text-transform: uppercase;
-          display: inline-flex; align-items: center; gap: 4px; padding: 0;
-          transition: color 0.15s;
+        .um-action-btn {
+          padding: 4px 11px; border-radius: 7px; font-size: 11px;
+          font-weight: 600; font-family: inherit; cursor: pointer;
+          border: none; transition: all 0.15s; white-space: nowrap;
+          display: inline-flex; align-items: center; gap: 4px;
         }
-        .um-sort-btn:hover  { color: #2563eb; }
-        .um-sort-btn.active { color: #2563eb; }
-
+        .um-action-btn:hover:not(:disabled) { transform: translateY(-1px); filter: brightness(0.92); }
+        .um-action-btn:disabled { opacity: 0.4; cursor: not-allowed; }
         .um-select {
           appearance: none; -webkit-appearance: none;
           padding: 7px 28px 7px 10px; border-radius: 9px;
@@ -299,45 +487,17 @@ export default function UserManagementPage() {
           background: ${cardBg} url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpath d='M2 3.5l3 3 3-3' stroke='%239ca3af' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E") no-repeat right 8px center;
           color: ${text}; font-size: 13px; font-weight: 500;
           font-family: inherit; cursor: pointer; outline: none;
-          transition: border-color 0.15s;
-        }
-        .um-select:focus { border-color: #2563eb; }
-
-        .um-action-btn {
-          padding: 5px 12px; border-radius: 7px; font-size: 11.5px;
-          font-weight: 600; font-family: inherit; cursor: pointer;
-          border: none; transition: all 0.15s; white-space: nowrap;
-        }
-        .um-action-btn:hover:not(:disabled) { transform: translateY(-1px); }
-
-        .um-search-wrap {
-          display: flex; align-items: center; gap: 8px;
-          background: ${cardBg}; border: 1px solid ${border};
-          border-radius: 10px; padding: 0 12px; height: 38px; width: 240px;
-          transition: border-color 0.2s, box-shadow 0.2s;
-        }
-        .um-search-wrap:focus-within {
-          border-color: #93c5fd;
-          box-shadow: 0 0 0 3px rgba(147,197,253,0.2);
-        }
-        .um-search-wrap input {
-          border: none; outline: none; font-size: 13px;
-          background: transparent; width: 100%;
-          font-family: inherit; color: ${text};
         }
       `}</style>
 
       {/* Toast */}
       {toastMsg && (
         <div style={{ position: "fixed", bottom: 24, right: 24, zIndex: 9999,
-          background: dark ? "#1e293b" : "#111827", color: "#fff",
-          fontSize: 13, fontWeight: 500, padding: "10px 18px", borderRadius: 10,
-          boxShadow: "0 8px 24px rgba(0,0,0,0.25)", animation: "um-toastIn 0.25s ease",
-          display: "flex", alignItems: "center", gap: 8 }}>
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-            <circle cx="7" cy="7" r="5.5" fill="#22c55e"/>
-            <path d="M4.5 7l2 2 3-3" stroke="#fff" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
-          </svg>
+          background: toastType === "error" ? "#dc2626" : toastType === "warn" ? "#f59e0b" : (dark ? "#1e293b" : "#111827"),
+          color: "#fff", fontSize: 13, fontWeight: 500, padding: "10px 18px",
+          borderRadius: 10, boxShadow: "0 8px 24px rgba(0,0,0,0.25)",
+          animation: "um-toastIn 0.25s ease", display: "flex", alignItems: "center", gap: 8 }}>
+          {toastType === "success" ? "✅" : toastType === "warn" ? "⚠️" : "❌"}
           {toastMsg}
         </div>
       )}
@@ -347,64 +507,68 @@ export default function UserManagementPage() {
         justifyContent: "space-between", gap: 12, flexWrap: "wrap", marginBottom: 22 }}>
         <div>
           <p style={{ fontSize: 10, fontWeight: 700, letterSpacing: ".12em",
-            textTransform: "uppercase", color: "#2563eb", margin: "0 0 4px" }}>
-            Admin Portal
+            textTransform: "uppercase",
+            color: isSA ? "#7c3aed" : "#2563eb", margin: "0 0 4px" }}>
+            {isSA ? "⚡ Superadmin Portal" : "Admin Portal"}
           </p>
           <h1 style={{ fontSize: 26, fontWeight: 700, color: text, margin: 0, letterSpacing: "-0.02em" }}>
             User Management
           </h1>
           <p style={{ fontSize: 13, color: textMuted, margin: "5px 0 0" }}>
-            Manage student and admin access to the Knowledge Map.
+            {isSA
+              ? "Full access — manage roles, block, unblock, and delete users."
+              : "You can block, unblock, and delete regular students."}
           </p>
         </div>
-        <button onClick={fetchUsers} style={{ display: "inline-flex", alignItems: "center", gap: 6,
-          padding: "8px 16px", borderRadius: 10, border: `1px solid ${border}`,
-          background: cardBg, color: textMuted, fontSize: 13, fontWeight: 600,
-          fontFamily: "inherit", cursor: "pointer", transition: "all 0.15s" }}
-          onMouseEnter={e => e.currentTarget.style.borderColor = "#2563eb"}
-          onMouseLeave={e => e.currentTarget.style.borderColor = border}>
-          <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
-            <path d="M13.5 8A5.5 5.5 0 1 1 10 3.07" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
-            <polyline points="10,1 10,4 13,4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
-          </svg>
-          Refresh
-        </button>
+        <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+          {isSA && (
+            <button onClick={() => setAddAdminOpen(true)} style={{
+              display: "inline-flex", alignItems: "center", gap: 6,
+              padding: "8px 16px", borderRadius: 10,
+              background: "linear-gradient(135deg,#7c3aed,#8b5cf6)",
+              color: "#fff", border: "none", fontSize: 13, fontWeight: 600,
+              fontFamily: "inherit", cursor: "pointer",
+              boxShadow: "0 2px 10px rgba(124,58,237,0.35)", transition: "all 0.15s" }}
+              onMouseEnter={e => e.currentTarget.style.transform = "translateY(-1px)"}
+              onMouseLeave={e => e.currentTarget.style.transform = "none"}>
+              <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
+                <path d="M7 1v12M1 7h12" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+              </svg>
+              Add Admin
+            </button>
+          )}
+          <button onClick={fetchUsers} style={{ display: "inline-flex", alignItems: "center", gap: 6,
+            padding: "8px 16px", borderRadius: 10, border: `1px solid ${border}`,
+            background: cardBg, color: textMuted, fontSize: 13, fontWeight: 600,
+            fontFamily: "inherit", cursor: "pointer", transition: "all 0.15s" }}
+            onMouseEnter={e => e.currentTarget.style.borderColor = "#2563eb"}
+            onMouseLeave={e => e.currentTarget.style.borderColor = border}>
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+              <path d="M13.5 8A5.5 5.5 0 1 1 10 3.07" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+              <polyline points="10,1 10,4 13,4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+            Refresh
+          </button>
+        </div>
       </div>
 
       {/* Stat cards */}
       <div className="um-anim um-d1" style={{ display: "grid",
-        gridTemplateColumns: "repeat(3,1fr)", gap: 12, marginBottom: 22 }}>
+        gridTemplateColumns: "repeat(4,1fr)", gap: 12, marginBottom: 22 }}>
         {[
-          {
-            label: "Total Users", value: users.length,
-            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-              <circle cx="9" cy="6" r="3.5" stroke="#1d4ed8" strokeWidth="1.4"/>
-              <path d="M2.5 16c0-3.6 2.9-6 6.5-6s6.5 2.4 6.5 6" stroke="#1d4ed8" strokeWidth="1.4" strokeLinecap="round"/>
-            </svg>,
-            iconBg: dark ? "#1e3a5f" : "#eff6ff",
-          },
-          {
-            label: "Admins", value: adminCount,
-            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-              <path d="M9 2L11.5 7H16.5L12.5 10.3L14 15.5L9 12.5L4 15.5L5.5 10.3L1.5 7H6.5L9 2Z"
-                stroke="#d97706" strokeWidth="1.4" strokeLinejoin="round"/>
-            </svg>,
-            iconBg: dark ? "#2d1f07" : "#fffbeb",
-          },
-          {
-            label: "Students", value: userCount,
-            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-              <path d="M9 2l7 3.5-7 3.5-7-3.5L9 2Z" stroke="#15803d" strokeWidth="1.4" strokeLinejoin="round"/>
-              <path d="M16 5.5v5M4 9v4.5c0 1.5 2.2 3 5 3s5-1.5 5-3V9"
-                stroke="#15803d" strokeWidth="1.4" strokeLinecap="round"/>
-            </svg>,
-            iconBg: dark ? "#14301f" : "#f0fdf4",
-          },
+          { label: "Total Users",  value: users.length,  iconBg: dark ? "#1e3a5f" : "#eff6ff",
+            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="6" r="3.5" stroke="#1d4ed8" strokeWidth="1.4"/><path d="M2.5 16c0-3.6 2.9-6 6.5-6s6.5 2.4 6.5 6" stroke="#1d4ed8" strokeWidth="1.4" strokeLinecap="round"/></svg> },
+          { label: "Superadmins",  value: saCount,       iconBg: dark ? "#1e1040" : "#f5f3ff",
+            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none"><path d="M9 2l1.5 4H15l-3.5 2.5 1.3 4L9 10l-3.8 2.5 1.3-4L3 6h4.5L9 2Z" stroke="#7c3aed" strokeWidth="1.4" strokeLinejoin="round"/></svg> },
+          { label: "Admins",       value: adminCount,    iconBg: dark ? "#2d1f07" : "#fffbeb",
+            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none"><path d="M9 2l1.5 3H14l-3 2.2 1 3.3L9 8.5l-3 2 1-3.3L4 5h3.5L9 2Z" stroke="#d97706" strokeWidth="1.4" strokeLinejoin="round"/></svg> },
+          { label: "Blocked",      value: blockedCount,  iconBg: dark ? "#3b0f14" : "#fff1f2",
+            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="9" r="6.5" stroke="#dc2626" strokeWidth="1.4"/><line x1="4" y1="4" x2="14" y2="14" stroke="#dc2626" strokeWidth="1.4" strokeLinecap="round"/></svg> },
         ].map(s => (
           <div key={s.label} style={{ background: cardBg, border: `1px solid ${border}`,
-            borderRadius: 12, padding: "16px 18px",
-            display: "flex", alignItems: "center", gap: 14 }}>
-            <div style={{ width: 40, height: 40, borderRadius: 10, background: s.iconBg,
+            borderRadius: 12, padding: "14px 16px",
+            display: "flex", alignItems: "center", gap: 12 }}>
+            <div style={{ width: 38, height: 38, borderRadius: 10, background: s.iconBg,
               display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
               {s.icon}
             </div>
@@ -412,7 +576,7 @@ export default function UserManagementPage() {
               <p style={{ margin: 0, fontSize: 22, fontWeight: 700, color: text, lineHeight: 1 }}>
                 {s.value}
               </p>
-              <p style={{ margin: "3px 0 0", fontSize: 12, color: textMuted, fontWeight: 500 }}>
+              <p style={{ margin: "3px 0 0", fontSize: 11, color: textMuted, fontWeight: 500 }}>
                 {s.label}
               </p>
             </div>
@@ -428,16 +592,21 @@ export default function UserManagementPage() {
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between",
           padding: "12px 16px", borderBottom: `1px solid ${border}`,
           background: filterBg, flexWrap: "wrap", gap: 10 }}>
-          <div className="um-search-wrap">
+          <div style={{ display: "flex", alignItems: "center", gap: 8,
+            background: cardBg, border: `1px solid ${border}`,
+            borderRadius: 10, padding: "0 12px", height: 38, width: 240 }}>
             <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
               <circle cx="7" cy="7" r="5.5" stroke={textMuted} strokeWidth="1.4"/>
               <path d="M11.5 11.5l2.5 2.5" stroke={textMuted} strokeWidth="1.4" strokeLinecap="round"/>
             </svg>
             <input type="text" placeholder="Search by name or email…"
-              value={search} onChange={e => setSearch(e.target.value)} />
+              value={search} onChange={e => setSearch(e.target.value)}
+              style={{ border: "none", outline: "none", fontSize: 13,
+                background: "transparent", width: "100%",
+                fontFamily: "inherit", color: text }} />
             {search && (
-              <button onClick={() => setSearch("")} style={{ background: "none", border: "none",
-                cursor: "pointer", color: textMuted, padding: 0, display: "flex" }}>
+              <button onClick={() => setSearch("")} style={{ background: "none",
+                border: "none", cursor: "pointer", color: textMuted, padding: 0, display: "flex" }}>
                 <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
                   <path d="M2 2l8 8M10 2l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
                 </svg>
@@ -447,8 +616,10 @@ export default function UserManagementPage() {
           <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
             <select className="um-select" value={filterRole} onChange={e => setFilterRole(e.target.value)}>
               <option value="all">All Roles</option>
-              <option value="admin">Admins only</option>
-              <option value="user">Students only</option>
+              <option value="superadmin">Superadmins</option>
+              <option value="admin">Admins</option>
+              <option value="user">Students</option>
+              <option value="blocked">Blocked</option>
             </select>
             <select className="um-select" value={sortBy} onChange={e => setSortBy(e.target.value)}>
               <option value="lastLogin">Last Login</option>
@@ -474,16 +645,7 @@ export default function UserManagementPage() {
         {!error && filtered.length === 0 ? (
           <div style={{ display: "flex", flexDirection: "column", alignItems: "center",
             justifyContent: "center", padding: "64px 24px", color: textMuted }}>
-            <div style={{ width: 52, height: 52, borderRadius: 14,
-              background: dark ? "#1f2937" : "#f3f4f6",
-              display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 16 }}>
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                <circle cx="9" cy="7" r="4" stroke={dark ? "#4b5563" : "#d1d5db"} strokeWidth="1.5"/>
-                <path d="M3 20c0-4 2.7-6 6-6s6 2 6 6"
-                  stroke={dark ? "#4b5563" : "#d1d5db"} strokeWidth="1.5" strokeLinecap="round"/>
-              </svg>
-            </div>
-            <p style={{ fontSize: 14, fontWeight: 600, color: textMuted, marginBottom: 4 }}>
+            <p style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>
               {search || filterRole !== "all" ? "No users match your filters" : "No users found"}
             </p>
             <p style={{ fontSize: 12, color: dark ? "#4b5563" : "#9ca3af" }}>
@@ -497,98 +659,76 @@ export default function UserManagementPage() {
             <table style={{ width: "100%", borderCollapse: "collapse" }}>
               <thead>
                 <tr style={{ background: theadBg }}>
-                  {[
-                    { key: "name",      label: "User"       },
-                    { key: "role",      label: "Role"       },
-                    { key: "email",     label: "Email"      },
-                    { key: "lastLogin", label: "Last Login" },
-                    { key: null,        label: "Actions"    },
-                  ].map(col => (
-                    <th key={col.label} style={{ padding: "10px 16px", textAlign: "left",
+                  {["User", "Role", "Email", "Last Login", "Actions"].map(h => (
+                    <th key={h} style={{ padding: "10px 16px", textAlign: "left",
+                      fontSize: 11, fontWeight: 700, color: textMuted,
+                      letterSpacing: ".07em", textTransform: "uppercase",
                       borderBottom: `1px solid ${border}`, whiteSpace: "nowrap" }}>
-                      {col.key ? (
-                        <button className={`um-sort-btn${sortBy === col.key ? " active" : ""}`}
-                          onClick={() => setSortBy(col.key)}>
-                          {col.label}
-                          <svg width="8" height="8" viewBox="0 0 8 8" fill="none"
-                            style={{ opacity: sortBy === col.key ? 1 : 0.35 }}>
-                            <path d="M1 3l3-2 3 2M1 5l3 2 3-2"
-                              stroke="currentColor" strokeWidth="1.3"
-                              strokeLinecap="round" strokeLinejoin="round"/>
-                          </svg>
-                        </button>
-                      ) : (
-                        <span style={{ fontSize: 11, fontWeight: 700, color: textMuted,
-                          letterSpacing: ".07em", textTransform: "uppercase" }}>
-                          {col.label}
-                        </span>
-                      )}
+                      {h}
                     </th>
                   ))}
                 </tr>
               </thead>
               <tbody>
                 {filtered.map((u, idx) => {
-                  const isCurrentUser = u.email === currentUser?.email;
-                  const isAdmin       = u.role === "admin";
+                  const isMe       = u.email === currentUser?.email;
+                  const isTargetSA = u.role === "superadmin";
+                  const badge      = roleBadge(u);
+                  const actions    = getAvailableActions(u);
+
                   return (
-                    <tr key={u.id} className="um-row" style={{
+                    <tr key={u.id || u.email} className="um-row" style={{
                       borderBottom: `1px solid ${border}`,
                       animation: "um-slideUp 0.3s ease both",
-                      animationDelay: `${idx * 0.025}s` }}>
+                      animationDelay: `${idx * 0.025}s`,
+                      opacity: u.isBlocked ? 0.75 : 1 }}>
 
                       {/* User */}
                       <td style={{ padding: "14px 16px", verticalAlign: "middle" }}>
                         <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
                           <div style={{ position: "relative", flexShrink: 0 }}>
                             <Avatar user={u} size={36} />
-                            {isAdmin && (
+                            {isTargetSA && (
                               <div style={{ position: "absolute", bottom: -2, right: -2,
-                                width: 14, height: 14, borderRadius: "50%", background: "#f59e0b",
-                                border: `2px solid ${cardBg}`, display: "flex",
-                                alignItems: "center", justifyContent: "center" }}>
-                                <svg width="7" height="7" viewBox="0 0 10 10" fill="none">
-                                  <path d="M5 1l1.5 3H10L7.5 6l1 3.5L5 8l-3.5 1.5 1-3.5L0 4h3.5L5 1Z" fill="#fff"/>
-                                </svg>
-                              </div>
+                                width: 14, height: 14, borderRadius: "50%",
+                                background: "#7c3aed", border: `2px solid ${cardBg}`,
+                                display: "flex", alignItems: "center",
+                                justifyContent: "center", fontSize: 8 }}>⚡</div>
                             )}
                           </div>
                           <div style={{ minWidth: 0 }}>
                             <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
                               <span style={{ fontSize: 14, fontWeight: 600, color: text,
                                 whiteSpace: "nowrap", overflow: "hidden",
-                                textOverflow: "ellipsis", maxWidth: 180 }}>
+                                textOverflow: "ellipsis", maxWidth: 160 }}>
                                 {u.displayName || "—"}
                               </span>
-                              {isCurrentUser && (
-                                <span style={{ fontSize: 9, fontWeight: 700, padding: "1px 6px",
-                                  borderRadius: 999,
+                              {isMe && (
+                                <span style={{ fontSize: 9, fontWeight: 700,
+                                  padding: "1px 6px", borderRadius: 999,
                                   background: dark ? "#1e3a5f" : "#dbeafe",
                                   color: dark ? "#93c5fd" : "#1d4ed8",
-                                  letterSpacing: ".05em", textTransform: "uppercase", whiteSpace: "nowrap" }}>
+                                  letterSpacing: ".05em", textTransform: "uppercase",
+                                  whiteSpace: "nowrap" }}>
                                   You
                                 </span>
                               )}
                             </div>
                             <p style={{ margin: 0, fontSize: 11, color: textMuted,
                               fontFamily: "'DM Mono','Fira Code',monospace" }}>
-                              {u.uid?.slice(0, 10)}…
+                              {u.uid ? `${u.uid.slice(0, 10)}…` : "—"}
                             </p>
                           </div>
                         </div>
                       </td>
 
-                      {/* Role */}
+                      {/* Role badge */}
                       <td style={{ padding: "14px 16px", verticalAlign: "middle" }}>
-                        <span style={{ display: "inline-flex", alignItems: "center", gap: 5,
+                        <span style={{ display: "inline-flex", alignItems: "center",
                           padding: "4px 10px", borderRadius: 999, fontSize: 11.5, fontWeight: 700,
-                          background: isAdmin
-                            ? (dark ? "#2d1f07" : "#fffbeb") : (dark ? "#1f2937" : "#f3f4f6"),
-                          color: isAdmin
-                            ? (dark ? "#fcd34d" : "#b45309") : (dark ? "#6b7280" : "#6b7280"),
-                          border: `1px solid ${isAdmin
-                            ? (dark ? "#854d0e" : "#fde68a") : (dark ? "#374151" : "#e5e7eb")}` }}>
-                          {isAdmin ? "⭐ Admin" : "👤 Student"}
+                          background: badge.bg, color: badge.color,
+                          border: `1px solid ${badge.border}` }}>
+                          {badge.label}
                         </span>
                       </td>
 
@@ -609,27 +749,66 @@ export default function UserManagementPage() {
 
                       {/* Actions */}
                       <td style={{ padding: "14px 16px", verticalAlign: "middle" }}>
-                        {isCurrentUser ? (
-                          <span style={{ fontSize: 11.5,
-                            color: dark ? "#475569" : "#d1d5db", fontStyle: "italic" }}>
-                            (current session)
-                          </span>
-                        ) : isAdmin ? (
-                          <button className="um-action-btn"
-                            onClick={() => setConfirmDialog({ open: true, user: u, action: "demote" })}
-                            style={{ background: dark ? "#2d0a14" : "#fff1f2",
-                              color: dark ? "#fca5a5" : "#be123c",
-                              border: `1px solid ${dark ? "#7f1d1d" : "#fecdd3"}` }}>
-                            Remove Admin
-                          </button>
+                        {isMe ? (
+                          <span style={{ fontSize: 11.5, color: dark ? "#475569" : "#d1d5db",
+                            fontStyle: "italic" }}>(you)</span>
+                        ) : isTargetSA ? (
+                          <span style={{ fontSize: 11.5, color: dark ? "#475569" : "#d1d5db",
+                            fontStyle: "italic" }}>Protected</span>
                         ) : (
-                          <button className="um-action-btn"
-                            onClick={() => setConfirmDialog({ open: true, user: u, action: "promote" })}
-                            style={{ background: dark ? "#1e3a5f" : "#eff6ff",
-                              color: dark ? "#93c5fd" : "#1d4ed8",
-                              border: `1px solid ${dark ? "#1d4ed8" : "#bfdbfe"}` }}>
-                            Make Admin
-                          </button>
+                          <div style={{ display: "flex", gap: 5, flexWrap: "wrap" }}>
+                            {actions.canPromote && (
+                              <button className="um-action-btn"
+                                onClick={() => openConfirm(u, "promote")}
+                                style={{ background: dark ? "#1e3a5f" : "#eff6ff",
+                                  color: dark ? "#93c5fd" : "#1d4ed8",
+                                  border: `1px solid ${dark ? "#1d4ed8" : "#bfdbfe"}` }}>
+                                ⭐ Make Admin
+                              </button>
+                            )}
+                            {actions.canDemote && (
+                              <button className="um-action-btn"
+                                onClick={() => openConfirm(u, "demote")}
+                                style={{ background: dark ? "#2d1f07" : "#fffbeb",
+                                  color: dark ? "#fcd34d" : "#b45309",
+                                  border: `1px solid ${dark ? "#854d0e" : "#fde68a"}` }}>
+                                👤 Remove Admin
+                              </button>
+                            )}
+                            {actions.canBlock && (
+                              <button className="um-action-btn"
+                                onClick={() => openConfirm(u, "block")}
+                                style={{ background: dark ? "#2d1f07" : "#fffbeb",
+                                  color: dark ? "#fbbf24" : "#b45309",
+                                  border: `1px solid ${dark ? "#92400e" : "#fde68a"}` }}>
+                                🚫 Block
+                              </button>
+                            )}
+                            {actions.canUnblock && (
+                              <button className="um-action-btn"
+                                onClick={() => openConfirm(u, "unblock")}
+                                style={{ background: dark ? "#14301f" : "#f0fdf4",
+                                  color: dark ? "#86efac" : "#15803d",
+                                  border: `1px solid ${dark ? "#166534" : "#bbf7d0"}` }}>
+                                ✅ Unblock
+                              </button>
+                            )}
+                            {actions.canDelete && (
+                              <button className="um-action-btn"
+                                onClick={() => openConfirm(u, "delete")}
+                                style={{ background: dark ? "#2d0a14" : "#fff1f2",
+                                  color: dark ? "#fca5a5" : "#be123c",
+                                  border: `1px solid ${dark ? "#7f1d1d" : "#fecdd3"}` }}>
+                                🗑️ Delete
+                              </button>
+                            )}
+                            {!actions.canPromote && !actions.canDemote &&
+                             !actions.canBlock && !actions.canUnblock && !actions.canDelete && (
+                              <span style={{ fontSize: 11.5,
+                                color: dark ? "#475569" : "#d1d5db",
+                                fontStyle: "italic" }}>No actions</span>
+                            )}
+                          </div>
                         )}
                       </td>
                     </tr>
@@ -656,6 +835,12 @@ export default function UserManagementPage() {
         user={confirmDialog.user}
         action={confirmDialog.action}
         loading={actionLoading}
+        dark={dark}
+      />
+      <AddAdminModal
+        isOpen={addAdminOpen}
+        onClose={() => setAddAdminOpen(false)}
+        onAdded={(email) => { showToast(`${email} added as Admin.`); fetchUsers(); }}
         dark={dark}
       />
     </div>

--- a/src/pages/UserManagementPage.jsx
+++ b/src/pages/UserManagementPage.jsx
@@ -1,3 +1,4 @@
+// src/pages/UserManagementPage.jsx
 import { useState, useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 import {
@@ -6,21 +7,80 @@ import {
   demoteFromAdmin,
   blockUser,
   unblockUser,
-  deleteUser,
   addAdminByEmail,
-  getUserRole,        // <-- NEW: to check superadmin status
+  getUserRole,
 } from "../services/userService";
 import { useAuth } from "../context/useAuth";
 import { Navigate } from "react-router-dom";
 
-// ── Helpers ───────────────────────────────────────────────────────────────
+// ---------- Professional SVG Icons ----------
+const IconShield = () => (
+  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 2L3 7v7c0 5 9 8 9 8s9-3 9-8V7l-9-5z" />
+    <path d="M12 8v4M12 16h.01" />
+  </svg>
+);
+
+const IconUser = () => (
+  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+    <circle cx="12" cy="7" r="4" />
+  </svg>
+);
+
+const IconBan = () => (
+  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2">
+    <circle cx="12" cy="12" r="10" />
+    <line x1="4.93" y1="4.93" x2="19.07" y2="19.07" />
+  </svg>
+);
+
+const IconCheck = () => (
+  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+const IconRefresh = () => (
+  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M23 4v6h-6" />
+    <path d="M1 20v-6h6" />
+    <path d="M3.51 9a9 9 0 0 1 14.21-2.48L23 12" />
+    <path d="M20.49 15a9 9 0 0 1-14.21 2.48L1 12" />
+  </svg>
+);
+
+const IconPlus = () => (
+  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2">
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
+const IconUsers = () => (
+  <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+    <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+  </svg>
+);
+
+const IconSearch = () => (
+  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2">
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);
+
+// ---------- Helper Functions ----------
 function timeAgo(date) {
   if (!date) return "Never";
-  const d   = date?.toDate ? date.toDate() : new Date(date);
+  const d = date?.toDate ? date.toDate() : new Date(date);
   const sec = Math.floor((Date.now() - d.getTime()) / 1000);
-  if (sec < 60)     return "Just now";
-  if (sec < 3600)   return `${Math.floor(sec / 60)}m ago`;
-  if (sec < 86400)  return `${Math.floor(sec / 3600)}h ago`;
+  if (sec < 60) return "Just now";
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`;
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`;
   if (sec < 604800) return `${Math.floor(sec / 86400)}d ago`;
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 }
@@ -30,100 +90,247 @@ function Avatar({ user, size = 36 }) {
   const initial = (user.displayName || user.email || "?")[0].toUpperCase();
   if (user.photoURL && !imgErr) {
     return (
-      <img src={user.photoURL} alt={user.displayName}
+      <img
+        src={user.photoURL}
+        alt={user.displayName}
         onError={() => setImgErr(true)}
-        style={{ width: size, height: size, borderRadius: "50%",
-          objectFit: "cover", flexShrink: 0 }} />
+        style={{ width: size, height: size, borderRadius: "50%", objectFit: "cover", flexShrink: 0 }}
+      />
     );
   }
   return (
-    <div style={{ width: size, height: size, borderRadius: "50%",
-      background: "linear-gradient(135deg,#1d4ed8,#3b82f6)",
-      display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: "linear-gradient(135deg,#1d4ed8,#3b82f6)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+      }}
+    >
       <span style={{ color: "#fff", fontWeight: 700, fontSize: size * 0.38 }}>{initial}</span>
     </div>
   );
 }
 
-// ── Confirm Dialog ────────────────────────────────────────────────────────
+// ---------- Confirm Dialog (solid background) ----------
 function ConfirmDialog({ isOpen, onClose, onConfirm, user, action, loading, dark }) {
   if (!isOpen || !user) return null;
 
   const configs = {
-    promote: { color: "#1d4ed8", bg: dark ? "#1e3a5f" : "#dbeafe", label: "Promote to Admin",  icon: "⭐", desc: `${user.displayName || user.email} will gain admin privileges.` },
-    demote:  { color: "#dc2626", bg: dark ? "#3b0f14" : "#fee2e2", label: "Remove Admin",       icon: "👤", desc: `${user.displayName || user.email} will revert to a regular user.` },
-    block:   { color: "#f59e0b", bg: dark ? "#2d1f07" : "#fffbeb", label: "Block User",         icon: "🚫", desc: `${user.displayName || user.email} will be blocked from signing in.` },
-    unblock: { color: "#22c55e", bg: dark ? "#14301f" : "#f0fdf4", label: "Unblock User",       icon: "✅", desc: `${user.displayName || user.email} will be allowed to sign in again.` },
-    delete:  { color: "#dc2626", bg: dark ? "#3b0f14" : "#fee2e2", label: "Delete User",        icon: "🗑️", desc: `This will permanently delete ${user.email}. This cannot be undone.` },
+    promote: { 
+      color: "#1d4ed8", 
+      label: "Promote to Admin", 
+      icon: <IconShield />, 
+      title: "Promote User",
+      message: `${user.displayName || user.email} will gain full admin privileges. They will be able to manage courses, users, and system settings.`,
+      confirmText: "Promote",
+      hint: "This action can be reversed later."
+    },
+    demote: { 
+      color: "#dc2626", 
+      label: "Remove Admin", 
+      icon: <IconUser />, 
+      title: "Remove Admin Privileges",
+      message: `${user.displayName || user.email} will lose all admin access and become a regular student.`,
+      confirmText: "Remove",
+      hint: "This action can be reversed by promoting again."
+    },
+    block: { 
+      color: "#f59e0b", 
+      label: "Block User", 
+      icon: <IconBan />, 
+      title: "Block User Account",
+      message: `${user.displayName || user.email} will be unable to sign in. All their data remains intact.`,
+      confirmText: "Block",
+      hint: "You can unblock them later."
+    },
+    unblock: { 
+      color: "#22c55e", 
+      label: "Unblock User", 
+      icon: <IconCheck />, 
+      title: "Unblock User Account",
+      message: `${user.displayName || user.email} will be able to sign in again.`,
+      confirmText: "Unblock",
+      hint: "Their account will be restored to normal."
+    },
   };
   const cfg = configs[action] || configs.promote;
 
   return createPortal(
-    <div style={{ position: "fixed", inset: 0, zIndex: 60,
-      background: "rgba(15,23,42,0.65)", backdropFilter: "blur(4px)",
-      display: "flex", alignItems: "center", justifyContent: "center", padding: 16,
-      fontFamily: "'DM Sans', system-ui, sans-serif", animation: "um-fadeIn 0.15s ease" }}>
-      <div style={{ background: dark ? "#1e293b" : "#fff", borderRadius: 16,
-        width: "100%", maxWidth: 420, boxShadow: "0 24px 64px rgba(0,0,0,0.25)",
-        animation: "um-scaleIn 0.2s cubic-bezier(0.34,1.2,0.64,1)", overflow: "hidden" }}>
-
-        <div style={{ padding: "28px 28px 20px", display: "flex",
-          flexDirection: "column", alignItems: "center", gap: 12,
-          borderBottom: `1px solid ${dark ? "#334155" : "#f3f4f6"}` }}>
-          <div style={{ width: 52, height: 52, borderRadius: "50%",
-            background: cfg.bg, display: "flex", alignItems: "center",
-            justifyContent: "center", fontSize: 22 }}>
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 60,
+        background: "rgba(0, 0, 0, 0.5)", // semi-transparent backdrop
+        backdropFilter: "blur(2px)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 16,
+        fontFamily: "'DM Sans', system-ui, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          background: dark ? "#1e293b" : "#fff",
+          borderRadius: 20,
+          width: "100%",
+          maxWidth: 440,
+          boxShadow: "0 25px 50px -12px rgba(0,0,0,0.25)",
+          overflow: "hidden",
+          animation: "um-scaleIn 0.2s cubic-bezier(0.34,1.2,0.64,1)",
+        }}
+      >
+        {/* Header with icon and title */}
+        <div
+          style={{
+            padding: "20px 24px 12px",
+            borderBottom: `1px solid ${dark ? "#334155" : "#f1f5f9"}`,
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
+          <div
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: 12,
+              background: cfg.color + "15",
+              color: cfg.color,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 20,
+            }}
+          >
             {cfg.icon}
           </div>
-          <div style={{ textAlign: "center" }}>
-            <p style={{ margin: "0 0 5px", fontSize: 17, fontWeight: 700,
-              color: dark ? "#f1f5f9" : "#111827" }}>{cfg.label}?</p>
-            <p style={{ margin: 0, fontSize: 13, color: dark ? "#94a3b8" : "#6b7280", lineHeight: 1.5 }}>
-              {cfg.desc}
+          <div style={{ flex: 1 }}>
+            <h3 style={{ margin: 0, fontSize: 18, fontWeight: 700, color: dark ? "#f1f5f9" : "#0f172a" }}>
+              {cfg.title}
+            </h3>
+            <p style={{ margin: "4px 0 0", fontSize: 13, color: dark ? "#94a3b8" : "#475569" }}>
+              {cfg.label}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              background: "none",
+              border: "none",
+              color: dark ? "#64748b" : "#94a3b8",
+              fontSize: 24,
+              cursor: "pointer",
+              padding: 4,
+              lineHeight: 1,
+              borderRadius: 8,
+              transition: "background 0.15s",
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = dark ? "#334155" : "#f1f5f9")}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "none")}
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Message */}
+        <div style={{ padding: "20px 24px" }}>
+          <p style={{ margin: 0, fontSize: 14, lineHeight: 1.6, color: dark ? "#cbd5e1" : "#334155" }}>
+            {cfg.message}
+          </p>
+          <p style={{ margin: "12px 0 0", fontSize: 12, color: cfg.color, fontWeight: 500 }}>
+            {cfg.hint}
+          </p>
+        </div>
+
+        {/* User info card */}
+        <div
+          style={{
+            margin: "0 24px 16px",
+            padding: "12px 16px",
+            borderRadius: 12,
+            background: dark ? "#0f172a" : "#f8fafc",
+            border: `1px solid ${dark ? "#334155" : "#e2e8f0"}`,
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
+          <Avatar user={user} size={40} />
+          <div>
+            <p style={{ margin: 0, fontSize: 14, fontWeight: 600, color: dark ? "#f1f5f9" : "#0f172a" }}>
+              {user.displayName || user.email.split('@')[0]}
+            </p>
+            <p style={{ margin: "2px 0 0", fontSize: 12, color: dark ? "#94a3b8" : "#64748b" }}>
+              {user.email}
             </p>
           </div>
         </div>
 
-        <div style={{ padding: "14px 28px", borderBottom: `1px solid ${dark ? "#334155" : "#f3f4f6"}` }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px",
-            borderRadius: 10, background: dark ? "#0f172a" : "#f8fafc",
-            border: `1px solid ${dark ? "#334155" : "#e5e7eb"}` }}>
-            <Avatar user={user} size={32} />
-            <div style={{ minWidth: 0, flex: 1 }}>
-              <p style={{ margin: 0, fontSize: 13, fontWeight: 600,
-                color: dark ? "#f1f5f9" : "#111827",
-                overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                {user.displayName || "—"}
-              </p>
-              <p style={{ margin: 0, fontSize: 11, color: dark ? "#64748b" : "#9ca3af",
-                overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                {user.email}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div style={{ padding: "16px 28px", display: "flex", gap: 10, justifyContent: "flex-end" }}>
-          <button onClick={onClose} disabled={loading} style={{
-            padding: "9px 20px", borderRadius: 10,
-            border: `1px solid ${dark ? "#334155" : "#e5e7eb"}`,
-            background: dark ? "#1f2937" : "#f9fafb",
-            color: dark ? "#94a3b8" : "#374151",
-            fontSize: 13, fontWeight: 600, fontFamily: "inherit", cursor: "pointer" }}>
+        {/* Actions */}
+        <div style={{ padding: "16px 24px 24px", display: "flex", gap: 12, justifyContent: "flex-end" }}>
+          <button
+            onClick={onClose}
+            disabled={loading}
+            style={{
+              padding: "8px 20px",
+              borderRadius: 10,
+              border: `1px solid ${dark ? "#475569" : "#cbd5e1"}`,
+              background: "transparent",
+              color: dark ? "#cbd5e1" : "#475569",
+              fontSize: 13,
+              fontWeight: 600,
+              fontFamily: "inherit",
+              cursor: "pointer",
+              transition: "all 0.15s",
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = dark ? "#1e293b" : "#f1f5f9")}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+          >
             Cancel
           </button>
-          <button onClick={onConfirm} disabled={loading} style={{
-            padding: "9px 20px", borderRadius: 10, border: "none",
-            background: cfg.color, color: "#fff", fontSize: 13, fontWeight: 600,
-            fontFamily: "inherit", cursor: "pointer", opacity: loading ? 0.6 : 1,
-            display: "flex", alignItems: "center", gap: 7 }}>
+          <button
+            onClick={onConfirm}
+            disabled={loading}
+            style={{
+              padding: "8px 20px",
+              borderRadius: 10,
+              border: "none",
+              background: cfg.color,
+              color: "#fff",
+              fontSize: 13,
+              fontWeight: 600,
+              fontFamily: "inherit",
+              cursor: "pointer",
+              opacity: loading ? 0.7 : 1,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              transition: "transform 0.1s",
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.transform = "translateY(-1px)")}
+            onMouseLeave={(e) => (e.currentTarget.style.transform = "none")}
+          >
             {loading && (
-              <span style={{ width: 12, height: 12,
-                border: "2px solid rgba(255,255,255,0.3)", borderTopColor: "#fff",
-                borderRadius: "50%", display: "inline-block",
-                animation: "um-spin 0.7s linear infinite" }} />
+              <span
+                style={{
+                  width: 14,
+                  height: 14,
+                  border: "2px solid rgba(255,255,255,0.3)",
+                  borderTopColor: "#fff",
+                  borderRadius: "50%",
+                  display: "inline-block",
+                  animation: "um-spin 0.7s linear infinite",
+                }}
+              />
             )}
-            {loading ? "Saving…" : cfg.label}
+            {loading ? "Processing..." : cfg.confirmText}
           </button>
         </div>
       </div>
@@ -132,28 +339,25 @@ function ConfirmDialog({ isOpen, onClose, onConfirm, user, action, loading, dark
   );
 }
 
-// ── Add Admin Modal ───────────────────────────────────────────────────────
+// ---------- Add Admin Modal (solid background) ----------
 function AddAdminModal({ isOpen, onClose, onAdded, dark }) {
-  const [email,   setEmail]   = useState("");
+  const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
-  const [error,   setError]   = useState("");
+  const [error, setError] = useState("");
 
   const handleSubmit = async () => {
     const trimmed = email.trim().toLowerCase();
-    if (!trimmed)                          { setError("Email is required."); return; }
-    if (!trimmed.endsWith("@neu.edu.ph")) { setError("Only @neu.edu.ph emails allowed."); return; }
-
+    if (!trimmed) {
+      setError("Email is required.");
+      return;
+    }
+    if (!trimmed.endsWith("@neu.edu.ph")) {
+      setError("Only @neu.edu.ph emails are allowed.");
+      return;
+    }
     setLoading(true);
     setError("");
-
     try {
-      // Check if the user already exists and is a superadmin
-      const role = await getUserRole(trimmed);
-      if (role === "superadmin") {
-        setError("This user is a Superadmin and cannot be changed via this action.");
-        setLoading(false);
-        return;
-      }
       await addAdminByEmail(trimmed);
       onAdded(trimmed);
       setEmail("");
@@ -168,81 +372,182 @@ function AddAdminModal({ isOpen, onClose, onAdded, dark }) {
   if (!isOpen) return null;
 
   return createPortal(
-    <div style={{ position: "fixed", inset: 0, zIndex: 60,
-      background: "rgba(15,23,42,0.65)", backdropFilter: "blur(4px)",
-      display: "flex", alignItems: "center", justifyContent: "center", padding: 16,
-      fontFamily: "'DM Sans', system-ui, sans-serif", animation: "um-fadeIn 0.15s ease" }}>
-      <div style={{ background: dark ? "#1e293b" : "#fff", borderRadius: 16,
-        width: "100%", maxWidth: 400, boxShadow: "0 24px 64px rgba(0,0,0,0.25)",
-        animation: "um-scaleIn 0.2s cubic-bezier(0.34,1.2,0.64,1)" }}>
-
-        <div style={{ padding: "20px 24px 16px",
-          borderBottom: `1px solid ${dark ? "#334155" : "#f3f4f6"}`,
-          display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-          <div>
-            <p style={{ margin: 0, fontSize: 10, fontWeight: 700, letterSpacing: ".1em",
-              textTransform: "uppercase", color: dark ? "#475569" : "#9ca3af" }}>Superadmin</p>
-            <h3 style={{ margin: "3px 0 0", fontSize: 16, fontWeight: 700,
-              color: dark ? "#f1f5f9" : "#111827" }}>Add Admin by Email</h3>
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 60,
+        background: "rgba(0, 0, 0, 0.5)",
+        backdropFilter: "blur(2px)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 16,
+        fontFamily: "'DM Sans', system-ui, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          background: dark ? "#1e293b" : "#fff",
+          borderRadius: 20,
+          width: "100%",
+          maxWidth: 440,
+          boxShadow: "0 25px 50px -12px rgba(0,0,0,0.25)",
+          overflow: "hidden",
+          animation: "um-scaleIn 0.2s cubic-bezier(0.34,1.2,0.64,1)",
+        }}
+      >
+        <div
+          style={{
+            padding: "20px 24px 12px",
+            borderBottom: `1px solid ${dark ? "#334155" : "#f1f5f9"}`,
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
+          <div
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: 12,
+              background: "#7c3aed15",
+              color: "#7c3aed",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <IconPlus />
           </div>
-          <button onClick={onClose} style={{ background: "none", border: "none",
-            color: dark ? "#475569" : "#9ca3af", fontSize: 22, cursor: "pointer",
-            padding: 0, lineHeight: 1 }}>×</button>
+          <div style={{ flex: 1 }}>
+            <h3 style={{ margin: 0, fontSize: 18, fontWeight: 700, color: dark ? "#f1f5f9" : "#0f172a" }}>
+              Add Admin
+            </h3>
+            <p style={{ margin: "4px 0 0", fontSize: 13, color: dark ? "#94a3b8" : "#475569" }}>
+              Grant administrator access
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              background: "none",
+              border: "none",
+              color: dark ? "#64748b" : "#94a3b8",
+              fontSize: 24,
+              cursor: "pointer",
+              padding: 4,
+              lineHeight: 1,
+              borderRadius: 8,
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = dark ? "#334155" : "#f1f5f9")}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "none")}
+          >
+            ×
+          </button>
         </div>
 
-        <div style={{ padding: "20px 24px 24px" }}>
-          <p style={{ margin: "0 0 14px", fontSize: 13,
-            color: dark ? "#94a3b8" : "#6b7280", lineHeight: 1.5 }}>
-            Enter a <strong style={{ color: dark ? "#f1f5f9" : "#111827" }}>@neu.edu.ph</strong> email.
-            If the user hasn't logged in yet, they'll have admin access when they do.
+        <div style={{ padding: "20px 24px" }}>
+          <p style={{ margin: 0, fontSize: 14, lineHeight: 1.6, color: dark ? "#cbd5e1" : "#334155" }}>
+            Enter a <strong>@neu.edu.ph</strong> email address. If the user hasn't logged in before, they will be created with admin privileges. If they already exist, their role will be upgraded to admin.
           </p>
 
           {error && (
-            <div style={{ background: dark ? "rgba(220,38,38,0.1)" : "#fef2f2",
-              border: `1px solid ${dark ? "#7f1d1d" : "#fecaca"}`,
-              color: dark ? "#fca5a5" : "#b91c1c",
-              borderRadius: 8, padding: "9px 12px", fontSize: 12, marginBottom: 12 }}>
+            <div
+              style={{
+                marginTop: 16,
+                padding: "10px 14px",
+                borderRadius: 10,
+                background: dark ? "#7f1d1d20" : "#fef2f2",
+                border: `1px solid ${dark ? "#7f1d1d" : "#fecaca"}`,
+                color: dark ? "#fca5a5" : "#b91c1c",
+                fontSize: 13,
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+              }}
+            >
+              <IconBan style={{ width: 14, height: 14, flexShrink: 0 }} />
               {error}
             </div>
           )}
 
-          <input type="email" value={email}
-            onChange={e => setEmail(e.target.value)}
-            onKeyDown={e => e.key === "Enter" && handleSubmit()}
-            placeholder="e.g. juan.delacruz@neu.edu.ph"
-            style={{ width: "100%", height: 40, padding: "0 12px",
-              borderRadius: 10, fontSize: 13, fontFamily: "inherit",
-              border: `1.5px solid ${dark ? "#334155" : "#e5e7eb"}`,
-              background: dark ? "#0f172a" : "#f9fafb",
-              color: dark ? "#f1f5f9" : "#111827",
-              outline: "none", boxSizing: "border-box", transition: "border-color 0.15s" }}
-            onFocus={e  => e.target.style.borderColor = "#2563eb"}
-            onBlur={e   => e.target.style.borderColor = dark ? "#334155" : "#e5e7eb"}
-          />
-
-          <div style={{ display: "flex", gap: 10, justifyContent: "flex-end", marginTop: 16 }}>
-            <button onClick={onClose} style={{ padding: "9px 18px", borderRadius: 10,
-              border: `1px solid ${dark ? "#334155" : "#e5e7eb"}`,
-              background: dark ? "#1f2937" : "#f9fafb",
-              color: dark ? "#94a3b8" : "#374151",
-              fontSize: 13, fontWeight: 600, fontFamily: "inherit", cursor: "pointer" }}>
-              Cancel
-            </button>
-            <button onClick={handleSubmit} disabled={loading} style={{
-              padding: "9px 20px", borderRadius: 10, border: "none",
-              background: "linear-gradient(135deg,#1d4ed8,#2563eb)",
-              color: "#fff", fontSize: 13, fontWeight: 600, fontFamily: "inherit",
-              cursor: "pointer", opacity: loading ? 0.6 : 1,
-              display: "flex", alignItems: "center", gap: 7 }}>
-              {loading && (
-                <span style={{ width: 12, height: 12,
-                  border: "2px solid rgba(255,255,255,0.3)", borderTopColor: "#fff",
-                  borderRadius: "50%", display: "inline-block",
-                  animation: "um-spin 0.7s linear infinite" }} />
-              )}
-              {loading ? "Adding…" : "Add Admin"}
-            </button>
+          <div style={{ marginTop: 20 }}>
+            <label
+              style={{
+                display: "block",
+                fontSize: 12,
+                fontWeight: 600,
+                marginBottom: 6,
+                color: dark ? "#cbd5e1" : "#334155",
+              }}
+            >
+              Email address
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+              placeholder="e.g., juan.delacruz@neu.edu.ph"
+              style={{
+                width: "100%",
+                height: 44,
+                padding: "0 14px",
+                borderRadius: 12,
+                fontSize: 14,
+                fontFamily: "inherit",
+                border: `1.5px solid ${error ? "#dc2626" : dark ? "#475569" : "#cbd5e1"}`,
+                background: dark ? "#0f172a" : "#fff",
+                color: dark ? "#f1f5f9" : "#0f172a",
+                outline: "none",
+                transition: "border-color 0.15s",
+              }}
+              onFocus={(e) => (e.target.style.borderColor = "#7c3aed")}
+              onBlur={(e) => {
+                if (!error) e.target.style.borderColor = dark ? "#475569" : "#cbd5e1";
+              }}
+            />
           </div>
+        </div>
+
+        <div style={{ padding: "16px 24px 24px", display: "flex", gap: 12, justifyContent: "flex-end" }}>
+          <button
+            onClick={onClose}
+            style={{
+              padding: "8px 20px",
+              borderRadius: 10,
+              border: `1px solid ${dark ? "#475569" : "#cbd5e1"}`,
+              background: "transparent",
+              color: dark ? "#cbd5e1" : "#475569",
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={loading}
+            style={{
+              padding: "8px 20px",
+              borderRadius: 10,
+              border: "none",
+              background: "linear-gradient(135deg, #7c3aed, #8b5cf6)",
+              color: "#fff",
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: "pointer",
+              opacity: loading ? 0.7 : 1,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            {loading && <span className="um-spinner-small" />}
+            {loading ? "Adding..." : "Add Admin"}
+          </button>
         </div>
       </div>
     </div>,
@@ -250,37 +555,30 @@ function AddAdminModal({ isOpen, onClose, onAdded, dark }) {
   );
 }
 
-// ── Main Page ─────────────────────────────────────────────────────────────
+// ---------- Main Page ----------
 export default function UserManagementPage() {
   const { user: currentUser, role, authLoading } = useAuth();
+  const isSA = role === "superadmin";
+  const isAdminOrSA = role === "admin" || role === "superadmin";
 
-  // ── All hooks first — no exceptions ───────────────────────────────────
-  const [users,         setUsers]         = useState([]);
-  const [loading,       setLoading]       = useState(true);
-  const [error,         setError]         = useState(null);
-  const [search,        setSearch]        = useState("");
-  const [filterRole,    setFilterRole]    = useState("all");
-  const [sortBy,        setSortBy]        = useState("lastLogin");
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [search, setSearch] = useState("");
+  const [filterRole, setFilterRole] = useState("all");
+  const [sortBy, setSortBy] = useState("lastLogin");
   const [confirmDialog, setConfirmDialog] = useState({ open: false, user: null, action: null });
   const [actionLoading, setActionLoading] = useState(false);
-  const [toastMsg,      setToastMsg]      = useState(null);
-  const [toastType,     setToastType]     = useState("success");
-  const [addAdminOpen,  setAddAdminOpen]  = useState(false);
+  const [toastMsg, setToastMsg] = useState(null);
+  const [toastType, setToastType] = useState("success");
+  const [addAdminOpen, setAddAdminOpen] = useState(false);
 
-  const [dark, setDark] = useState(() =>
-    document.documentElement.classList.contains("dark")
-  );
-
+  const [dark, setDark] = useState(() => document.documentElement.classList.contains("dark"));
   useEffect(() => {
-    const obs = new MutationObserver(() =>
-      setDark(document.documentElement.classList.contains("dark"))
-    );
+    const obs = new MutationObserver(() => setDark(document.documentElement.classList.contains("dark")));
     obs.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
     return () => obs.disconnect();
   }, []);
-
-  const isSA        = role === "superadmin";
-  const isAdminOrSA = role === "admin" || role === "superadmin";
 
   const fetchUsers = useCallback(async () => {
     try {
@@ -299,76 +597,39 @@ export default function UserManagementPage() {
     if (!authLoading && isAdminOrSA) fetchUsers();
   }, [authLoading, isAdminOrSA, fetchUsers]);
 
-  // ── Guard — after all hooks ────────────────────────────────────────────
-  if (authLoading) return (
-    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: "60vh" }}>
-      <div style={{ textAlign: "center", fontFamily: "'DM Sans', system-ui, sans-serif" }}>
-        <div style={{ width: 36, height: 36, border: "2px solid #dbeafe",
-          borderTop: "2px solid #2563eb", borderRadius: "50%",
-          margin: "0 auto 12px", animation: "um-spin 0.8s linear infinite" }} />
-        <style>{`@keyframes um-spin { to { transform: rotate(360deg); } }`}</style>
-        <p style={{ fontSize: 13, color: "#6b7280" }}>Verifying session…</p>
-      </div>
-    </div>
-  );
-
   if (role && !isAdminOrSA) return <Navigate to="/home" replace />;
 
-  if (loading) return (
-    <div style={{ display: "flex", alignItems: "center", justifyContent: "center",
-      minHeight: "60vh", background: dark ? "#0f172a" : "#f9fafb" }}>
-      <div style={{ textAlign: "center", fontFamily: "'DM Sans', system-ui, sans-serif" }}>
-        <div style={{ width: 36, height: 36,
-          border: `2px solid ${dark ? "#1f2937" : "#dbeafe"}`,
-          borderTop: "2px solid #2563eb", borderRadius: "50%",
-          margin: "0 auto 12px", animation: "um-spin 0.8s linear infinite" }} />
-        <style>{`@keyframes um-spin { to { transform: rotate(360deg); } }`}</style>
-        <p style={{ fontSize: 13, color: dark ? "#9ca3af" : "#6b7280" }}>Loading users…</p>
-      </div>
-    </div>
-  );
-
-  // ── Helpers ────────────────────────────────────────────────────────────
   const showToast = (msg, type = "success") => {
-    setToastMsg(msg); setToastType(type);
+    setToastMsg(msg);
+    setToastType(type);
     setTimeout(() => setToastMsg(null), 3500);
   };
 
-  const openConfirm = (user, action) =>
-    setConfirmDialog({ open: true, user, action });
-
-  // ── What can the current user do to a target? ──────────────────────────
-  // Rules:
-  //   superadmin → can promote/demote/block/unblock/delete anyone EXCEPT other superadmins
-  //   admin      → can block/unblock/delete regular students ONLY
-  //   neither can touch themselves
   const getAvailableActions = (target) => {
     if (!target) return {};
-    const isMe          = target.email === currentUser?.email;
-    const isTargetSA    = target.role === "superadmin";
-    if (isMe || isTargetSA) return {};          // protected: yourself & superadmins
+    const isMe = target.email === currentUser?.email;
+    const isTargetSA = target.role === "superadmin";
+    if (isMe) return {};
+    if (isTargetSA) return {};
 
-    const targetIsAdmin   = target.role === "admin";
-    const targetIsUser    = target.role === "user";
-    const targetBlocked   = !!target.isBlocked;
+    const targetRole = target.role;
+    const targetBlocked = target.isBlocked;
 
     if (isSA) {
       return {
-        canPromote:  targetIsUser,              // only promote students → admin
-        canDemote:   targetIsAdmin,             // demote admin → student
-        canBlock:    !targetBlocked,
-        canUnblock:  targetBlocked,
-        canDelete:   true,                      // superadmin can delete anyone (except SAs)
+        canPromote: targetRole !== "admin" && targetRole !== "superadmin",
+        canDemote: targetRole === "admin",
+        canBlock: !targetBlocked,
+        canUnblock: targetBlocked,
       };
     }
 
     if (role === "admin") {
       return {
-        canPromote:  false,                     // admins cannot promote
-        canDemote:   false,                     // admins cannot demote
-        canBlock:    targetIsUser && !targetBlocked,
-        canUnblock:  targetIsUser && targetBlocked,
-        canDelete:   targetIsUser,              // admins can delete regular students
+        canPromote: false,
+        canDemote: false,
+        canBlock: targetRole === "user" && !targetBlocked,
+        canUnblock: targetRole === "user" && targetBlocked,
       };
     }
 
@@ -378,15 +639,27 @@ export default function UserManagementPage() {
   const handleAction = async () => {
     if (!confirmDialog.user) return;
     setActionLoading(true);
-    const { email } = confirmDialog.user;
+    const email = confirmDialog.user.email;
     try {
       switch (confirmDialog.action) {
-        case "promote":  await promoteToAdmin(email);  showToast(`${email} promoted to Admin.`); break;
-        case "demote":   await demoteFromAdmin(email); showToast(`${email} removed from Admin.`); break;
-        case "block":    await blockUser(email);       showToast(`${email} has been blocked.`,   "warn"); break;
-        case "unblock":  await unblockUser(email);     showToast(`${email} has been unblocked.`); break;
-        case "delete":   await deleteUser(email);      showToast(`${email} has been deleted.`,   "warn"); break;
-        default: break;
+        case "promote":
+          await promoteToAdmin(email);
+          showToast(`${email} promoted to Admin.`);
+          break;
+        case "demote":
+          await demoteFromAdmin(email);
+          showToast(`${email} removed from Admin.`);
+          break;
+        case "block":
+          await blockUser(email);
+          showToast(`${email} has been blocked.`, "warn");
+          break;
+        case "unblock":
+          await unblockUser(email);
+          showToast(`${email} has been unblocked.`);
+          break;
+        default:
+          break;
       }
       await fetchUsers();
       setConfirmDialog({ open: false, user: null, action: null });
@@ -397,231 +670,442 @@ export default function UserManagementPage() {
     }
   };
 
-  // ── Derived data ───────────────────────────────────────────────────────
+  const openConfirm = (user, action) => setConfirmDialog({ open: true, user, action });
+
   const filtered = users
-    .filter(u => {
-      const q = search.toLowerCase();
-      const matchSearch =
-        u.email?.toLowerCase().includes(q) ||
-        u.displayName?.toLowerCase().includes(q);
-      const matchRole =
-        filterRole === "all"        ? true :
-        filterRole === "superadmin" ? u.role === "superadmin" :
-        filterRole === "admin"      ? u.role === "admin" :
-        filterRole === "blocked"    ? u.isBlocked === true :
-                                      u.role === "user";
-      return matchSearch && matchRole;
+    .filter((u) => {
+        // Admin can only see regular student accounts (role === "user")
+        // and blocked students (which are also role === "user" with isBlocked true)
+        if (role === "admin" && (u.role === "admin" || u.role === "superadmin")) {
+        return false;
+        }
+        const q = search.toLowerCase();
+        const matchSearch = u.email?.toLowerCase().includes(q) || u.displayName?.toLowerCase().includes(q);
+        const matchRole =
+        filterRole === "all"
+            ? true
+            : filterRole === "superadmin"
+            ? u.role === "superadmin"
+            : filterRole === "admin"
+            ? u.role === "admin"
+            : filterRole === "blocked"
+            ? u.isBlocked
+            : u.role === "user";
+        return matchSearch && matchRole;
     })
     .sort((a, b) => {
-      if (sortBy === "name")  return (a.displayName || "").localeCompare(b.displayName || "");
+      if (sortBy === "name") return (a.displayName || "").localeCompare(b.displayName || "");
       if (sortBy === "email") return a.email.localeCompare(b.email);
-      if (sortBy === "role")  {
+      if (sortBy === "role") {
         const order = { superadmin: 0, admin: 1, user: 2 };
         return (order[a.role] ?? 3) - (order[b.role] ?? 3);
       }
-      const da  = a.lastLogin?.toDate?.() ?? new Date(a.lastLogin ?? 0);
-      const db_ = b.lastLogin?.toDate?.() ?? new Date(b.lastLogin ?? 0);
-      return db_ - da;
+      const da = a.lastLogin?.toDate?.() ?? new Date(a.lastLogin ?? 0);
+      const db = b.lastLogin?.toDate?.() ?? new Date(b.lastLogin ?? 0);
+      return db - da;
     });
 
-  const saCount      = users.filter(u => u.role === "superadmin").length;
-  const adminCount   = users.filter(u => u.role === "admin").length;
-  const studentCount = users.filter(u => u.role === "user").length;
-  const blockedCount = users.filter(u => u.isBlocked).length;
+  const saCount = users.filter((u) => u.role === "superadmin").length;
+  const adminCount = users.filter((u) => u.role === "admin").length;
+  const userCount = users.filter((u) => u.role === "user").length;
+  const blockedCount = users.filter((u) => u.isBlocked).length;
 
-  // ── Theme ──────────────────────────────────────────────────────────────
-  const bg        = dark ? "#0f172a" : "#f9fafb";
-  const cardBg    = dark ? "#111827" : "#fff";
-  const border    = dark ? "#1f2937" : "#e5e7eb";
-  const text      = dark ? "#f9fafb" : "#111827";
+  // Theme colors
+  const bg = dark ? "#0f172a" : "#f9fafb";
+  const cardBg = dark ? "#111827" : "#fff";
+  const border = dark ? "#1f2937" : "#e5e7eb";
+  const text = dark ? "#f9fafb" : "#111827";
   const textMuted = dark ? "#9ca3af" : "#6b7280";
-  const rowHover  = dark ? "#1a2234" : "#f8fafc";
-  const theadBg   = dark ? "#1a2234" : "#f8fafc";
-  const filterBg  = dark ? "#161f2e" : "#fafafa";
+  const rowHover = dark ? "#1a2234" : "#f8fafc";
+  const theadBg = dark ? "#1a2234" : "#f8fafc";
+  const filterBg = dark ? "#161f2e" : "#fafafa";
 
   const roleBadge = (u) => {
-    if (u.role === "superadmin") return {
-      bg: dark ? "#1e1040" : "#f5f3ff", color: dark ? "#c084fc" : "#7c3aed",
-      border: dark ? "#6d28d9" : "#ddd6fe", label: "⚡ Superadmin",
-    };
-    if (u.role === "admin") return {
-      bg: dark ? "#2d1f07" : "#fffbeb", color: dark ? "#fcd34d" : "#b45309",
-      border: dark ? "#854d0e" : "#fde68a", label: "⭐ Admin",
-    };
-    if (u.isBlocked) return {
-      bg: dark ? "#3b0f14" : "#fff1f2", color: dark ? "#fca5a5" : "#be123c",
-      border: dark ? "#7f1d1d" : "#fecdd3", label: "🚫 Blocked",
-    };
-    return {
-      bg: dark ? "#1f2937" : "#f3f4f6", color: dark ? "#6b7280" : "#6b7280",
-      border: dark ? "#374151" : "#e5e7eb", label: "👤 Student",
-    };
+    if (u.role === "superadmin")
+      return { bg: dark ? "#1e3a5f" : "#dbeafe", color: dark ? "#93c5fd" : "#1d4ed8", label: "Superadmin", icon: <IconShield /> };
+    if (u.role === "admin")
+      return { bg: dark ? "#2d1f07" : "#fffbeb", color: dark ? "#fcd34d" : "#b45309", label: "Admin", icon: <IconUser /> };
+    if (u.isBlocked)
+      return { bg: dark ? "#3b0f14" : "#fff1f2", color: dark ? "#fca5a5" : "#be123c", label: "Blocked", icon: <IconBan /> };
+    return { bg: dark ? "#1f2937" : "#f3f4f6", color: dark ? "#6b7280" : "#6b7280", label: "Student", icon: <IconUsers /> };
   };
 
+  if (authLoading)
+    return (
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: "60vh" }}>
+        <div style={{ textAlign: "center", fontFamily: "'DM Sans', system-ui, sans-serif" }}>
+          <div
+            style={{
+              width: 36,
+              height: 36,
+              border: "2px solid #dbeafe",
+              borderTop: "2px solid #2563eb",
+              borderRadius: "50%",
+              margin: "0 auto 12px",
+              animation: "um-spin 0.8s linear infinite",
+            }}
+          />
+          <p style={{ fontSize: 13, color: "#6b7280" }}>Verifying session…</p>
+        </div>
+      </div>
+    );
+
+  if (loading)
+    return (
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: "60vh", background: bg }}>
+        <div style={{ textAlign: "center", fontFamily: "'DM Sans', system-ui, sans-serif" }}>
+          <div
+            style={{
+              width: 36,
+              height: 36,
+              border: `2px solid ${dark ? "#1f2937" : "#dbeafe"}`,
+              borderTop: "2px solid #2563eb",
+              borderRadius: "50%",
+              margin: "0 auto 12px",
+              animation: "um-spin 0.8s linear infinite",
+            }}
+          />
+          <p style={{ fontSize: 13, color: textMuted }}>Loading users…</p>
+        </div>
+      </div>
+    );
+
   return (
-    <div style={{ maxWidth: 1200, margin: "0 auto", padding: "28px 24px",
-      fontFamily: "'DM Sans', system-ui, sans-serif", background: bg, minHeight: "100vh" }}>
+    <div
+      className="um-container"
+      style={{
+        maxWidth: 1200,
+        margin: "0 auto",
+        padding: "28px 24px",
+        fontFamily: "'DM Sans', system-ui, sans-serif",
+        background: bg,
+        minHeight: "100vh",
+      }}
+    >
       <style>{`
-        @keyframes um-fadeIn  { from{opacity:0} to{opacity:1} }
-        @keyframes um-scaleIn { from{opacity:0;transform:scale(0.95)} to{opacity:1;transform:scale(1)} }
-        @keyframes um-spin    { to{transform:rotate(360deg)} }
-        @keyframes um-slideUp { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
-        @keyframes um-toastIn { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:translateY(0)} }
+        @keyframes um-spin { to { transform: rotate(360deg); } }
+        @keyframes um-slideUp { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+        @keyframes um-toastIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
         .um-anim { animation: um-slideUp 0.35s ease both; }
-        .um-d1   { animation-delay: 0.03s; }
-        .um-d2   { animation-delay: 0.07s; }
-        .um-row  { transition: background 0.12s; }
+        .um-d1 { animation-delay: 0.03s; }
+        .um-d2 { animation-delay: 0.07s; }
+        .um-row { transition: background 0.12s; }
         .um-row:hover { background: ${rowHover} !important; }
-        .um-action-btn {
-          padding: 4px 11px; border-radius: 7px; font-size: 11px;
-          font-weight: 600; font-family: inherit; cursor: pointer;
-          border: none; transition: all 0.15s; white-space: nowrap;
-          display: inline-flex; align-items: center; gap: 4px;
+        .um-action-icon {
+          width: 32px;
+          height: 32px;
+          border-radius: 8px;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          cursor: pointer;
+          border: none;
+          transition: all 0.15s;
+          background: transparent;
+          color: ${textMuted};
         }
-        .um-action-btn:hover:not(:disabled) { transform: translateY(-1px); filter: brightness(0.92); }
-        .um-action-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+        .um-action-icon:hover { transform: translateY(-1px); filter: brightness(0.92); background: ${rowHover}; }
         .um-select {
-          appearance: none; -webkit-appearance: none;
-          padding: 7px 28px 7px 10px; border-radius: 9px;
+          appearance: none;
+          padding: 7px 28px 7px 10px;
+          border-radius: 9px;
           border: 1px solid ${border};
-          background: ${cardBg} url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpath d='M2 3.5l3 3 3-3' stroke='%239ca3af' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E") no-repeat right 8px center;
-          color: ${text}; font-size: 13px; font-weight: 500;
-          font-family: inherit; cursor: pointer; outline: none;
+          background: ${cardBg};
+          color: ${text};
+          font-size: 13px;
+          font-weight: 500;
+          font-family: inherit;
+          cursor: pointer;
+          outline: none;
+          background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpath d='M2 3.5l3 3 3-3' stroke='%239ca3af' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+          background-repeat: no-repeat;
+          background-position: right 8px center;
+        }
+          .um-spinner-small {
+            width: 14px;
+            height: 14px;
+            border: 2px solid rgba(255,255,255,0.3);
+            border-top-color: #fff;
+            border-radius: 50%;
+            display: inline-block;
+            animation: um-spin 0.7s linear infinite;
+            }
+
+        /* Responsive styles for mobile (max-width: 640px) */
+        @media (max-width: 640px) {
+          .um-stats-grid {
+            grid-template-columns: repeat(2, 1fr) !important;
+            gap: 10px !important;
+          }
+          .um-header {
+            flex-direction: column !important;
+            align-items: flex-start !important;
+          }
+          .um-header-actions {
+            width: 100% !important;
+            justify-content: flex-start !important;
+          }
+          .um-toolbar {
+            flex-direction: column !important;
+            align-items: stretch !important;
+          }
+          .um-search {
+            width: 100% !important;
+          }
+          .um-sort {
+            justify-content: space-between !important;
+            width: 100% !important;
+          }
+          .um-action-icon {
+            width: 28px !important;
+            height: 28px !important;
+          }
+          .um-stat-card {
+            padding: 10px 12px !important;
+          }
+          .um-stat-value {
+            font-size: 18px !important;
+          }
         }
       `}</style>
 
       {/* Toast */}
       {toastMsg && (
-        <div style={{ position: "fixed", bottom: 24, right: 24, zIndex: 9999,
-          background: toastType === "error" ? "#dc2626" : toastType === "warn" ? "#f59e0b" : (dark ? "#1e293b" : "#111827"),
-          color: "#fff", fontSize: 13, fontWeight: 500, padding: "10px 18px",
-          borderRadius: 10, boxShadow: "0 8px 24px rgba(0,0,0,0.25)",
-          animation: "um-toastIn 0.25s ease", display: "flex", alignItems: "center", gap: 8 }}>
-          {toastType === "success" ? "✅" : toastType === "warn" ? "⚠️" : "❌"}
+        <div
+          style={{
+            position: "fixed",
+            bottom: 24,
+            right: 24,
+            zIndex: 9999,
+            background: toastType === "error" ? "#dc2626" : toastType === "warn" ? "#f59e0b" : dark ? "#1e293b" : "#111827",
+            color: "#fff",
+            fontSize: 13,
+            fontWeight: 500,
+            padding: "10px 18px",
+            borderRadius: 10,
+            boxShadow: "0 8px 24px rgba(0,0,0,0.25)",
+            animation: "um-toastIn 0.25s ease",
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
+          {toastType === "success" && <IconCheck />}
+          {toastType === "warn" && <IconBan />}
+          {toastType === "error" && <IconBan />}
           {toastMsg}
         </div>
       )}
 
       {/* Header */}
-      <div className="um-anim um-d1" style={{ display: "flex", alignItems: "flex-start",
-        justifyContent: "space-between", gap: 12, flexWrap: "wrap", marginBottom: 22 }}>
+      <div
+        className="um-anim um-d1 um-header"
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          gap: 12,
+          flexWrap: "wrap",
+          marginBottom: 22,
+        }}
+      >
         <div>
-          <p style={{ fontSize: 10, fontWeight: 700, letterSpacing: ".12em",
-            textTransform: "uppercase",
-            color: isSA ? "#7c3aed" : "#2563eb", margin: "0 0 4px" }}>
-            {isSA ? "⚡ Superadmin Portal" : "Admin Portal"}
+          <p
+            style={{
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: ".12em",
+              textTransform: "uppercase",
+              color: isSA ? "#7c3aed" : "#2563eb",
+              margin: "0 0 4px",
+            }}
+          >
+            {isSA ? "Superadmin Portal" : "Admin Portal"}
           </p>
-          <h1 style={{ fontSize: 26, fontWeight: 700, color: text, margin: 0, letterSpacing: "-0.02em" }}>
-            User Management
-          </h1>
+          <h1 style={{ fontSize: 26, fontWeight: 700, color: text, margin: 0, letterSpacing: "-0.02em" }}>User Management</h1>
           <p style={{ fontSize: 13, color: textMuted, margin: "5px 0 0" }}>
-            {isSA
-              ? "Full access — manage roles, block, unblock, and delete users."
-              : "You can block, unblock, and delete regular students."}
+            {isSA ? "Full access — manage roles, block, and unblock users." : "You can block or unblock regular students."}
           </p>
         </div>
-        <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+        <div className="um-header-actions" style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
           {isSA && (
-            <button onClick={() => setAddAdminOpen(true)} style={{
-              display: "inline-flex", alignItems: "center", gap: 6,
-              padding: "8px 16px", borderRadius: 10,
-              background: "linear-gradient(135deg,#7c3aed,#8b5cf6)",
-              color: "#fff", border: "none", fontSize: 13, fontWeight: 600,
-              fontFamily: "inherit", cursor: "pointer",
-              boxShadow: "0 2px 10px rgba(124,58,237,0.35)", transition: "all 0.15s" }}
-              onMouseEnter={e => e.currentTarget.style.transform = "translateY(-1px)"}
-              onMouseLeave={e => e.currentTarget.style.transform = "none"}>
-              <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
-                <path d="M7 1v12M1 7h12" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
-              </svg>
-              Add Admin
+            <button
+              onClick={() => setAddAdminOpen(true)}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "8px 16px",
+                borderRadius: 10,
+                background: "linear-gradient(135deg,#7c3aed,#8b5cf6)",
+                color: "#fff",
+                border: "none",
+                fontSize: 13,
+                fontWeight: 600,
+                fontFamily: "inherit",
+                cursor: "pointer",
+                transition: "all 0.15s",
+                boxShadow: "0 2px 10px rgba(124,58,237,0.35)",
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.transform = "translateY(-1px)")}
+              onMouseLeave={(e) => (e.currentTarget.style.transform = "none")}
+            >
+              <IconPlus /> Add Admin
             </button>
           )}
-          <button onClick={fetchUsers} style={{ display: "inline-flex", alignItems: "center", gap: 6,
-            padding: "8px 16px", borderRadius: 10, border: `1px solid ${border}`,
-            background: cardBg, color: textMuted, fontSize: 13, fontWeight: 600,
-            fontFamily: "inherit", cursor: "pointer", transition: "all 0.15s" }}
-            onMouseEnter={e => e.currentTarget.style.borderColor = "#2563eb"}
-            onMouseLeave={e => e.currentTarget.style.borderColor = border}>
-            <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
-              <path d="M13.5 8A5.5 5.5 0 1 1 10 3.07" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
-              <polyline points="10,1 10,4 13,4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-            Refresh
+          <button
+            onClick={fetchUsers}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "8px 16px",
+              borderRadius: 10,
+              border: `1px solid ${border}`,
+              background: cardBg,
+              color: textMuted,
+              fontSize: 13,
+              fontWeight: 600,
+              fontFamily: "inherit",
+              cursor: "pointer",
+              transition: "all 0.15s",
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.borderColor = "#2563eb")}
+            onMouseLeave={(e) => (e.currentTarget.style.borderColor = border)}
+          >
+            <IconRefresh /> Refresh
           </button>
         </div>
       </div>
 
-      {/* Stat cards */}
-      <div className="um-anim um-d1" style={{ display: "grid",
-        gridTemplateColumns: "repeat(4,1fr)", gap: 12, marginBottom: 22 }}>
+      {/* Stat Cards */}
+      <div
+        className="um-anim um-d1 um-stats-grid"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(4,1fr)",
+          gap: 12,
+          marginBottom: 22,
+        }}
+      >
         {[
-          { label: "Total Users",  value: users.length,  iconBg: dark ? "#1e3a5f" : "#eff6ff",
-            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="6" r="3.5" stroke="#1d4ed8" strokeWidth="1.4"/><path d="M2.5 16c0-3.6 2.9-6 6.5-6s6.5 2.4 6.5 6" stroke="#1d4ed8" strokeWidth="1.4" strokeLinecap="round"/></svg> },
-          { label: "Superadmins",  value: saCount,       iconBg: dark ? "#1e1040" : "#f5f3ff",
-            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none"><path d="M9 2l1.5 4H15l-3.5 2.5 1.3 4L9 10l-3.8 2.5 1.3-4L3 6h4.5L9 2Z" stroke="#7c3aed" strokeWidth="1.4" strokeLinejoin="round"/></svg> },
-          { label: "Admins",       value: adminCount,    iconBg: dark ? "#2d1f07" : "#fffbeb",
-            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none"><path d="M9 2l1.5 3H14l-3 2.2 1 3.3L9 8.5l-3 2 1-3.3L4 5h3.5L9 2Z" stroke="#d97706" strokeWidth="1.4" strokeLinejoin="round"/></svg> },
-          { label: "Blocked",      value: blockedCount,  iconBg: dark ? "#3b0f14" : "#fff1f2",
-            icon: <svg width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="9" r="6.5" stroke="#dc2626" strokeWidth="1.4"/><line x1="4" y1="4" x2="14" y2="14" stroke="#dc2626" strokeWidth="1.4" strokeLinecap="round"/></svg> },
-        ].map(s => (
-          <div key={s.label} style={{ background: cardBg, border: `1px solid ${border}`,
-            borderRadius: 12, padding: "14px 16px",
-            display: "flex", alignItems: "center", gap: 12 }}>
-            <div style={{ width: 38, height: 38, borderRadius: 10, background: s.iconBg,
-              display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+          { label: "Total Users", value: users.length, icon: <IconUsers />, iconBg: dark ? "#1e3a5f" : "#eff6ff", color: "#1d4ed8" },
+          { label: "Superadmins", value: saCount, icon: <IconShield />, iconBg: dark ? "#1e1040" : "#f5f3ff", color: "#7c3aed" },
+          { label: "Admins", value: adminCount, icon: <IconUser />, iconBg: dark ? "#2d1f07" : "#fffbeb", color: "#d97706" },
+          { label: "Blocked", value: blockedCount, icon: <IconBan />, iconBg: dark ? "#3b0f14" : "#fff1f2", color: "#dc2626" },
+        ].map((s) => (
+          <div
+            key={s.label}
+            className="um-stat-card"
+            style={{
+              background: cardBg,
+              border: `1px solid ${border}`,
+              borderRadius: 12,
+              padding: "14px 16px",
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
+            }}
+          >
+            <div
+              style={{
+                width: 38,
+                height: 38,
+                borderRadius: 10,
+                background: s.iconBg,
+                color: s.color,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
               {s.icon}
             </div>
             <div>
-              <p style={{ margin: 0, fontSize: 22, fontWeight: 700, color: text, lineHeight: 1 }}>
+              <p className="um-stat-value" style={{ margin: 0, fontSize: 22, fontWeight: 700, color: text, lineHeight: 1 }}>
                 {s.value}
               </p>
-              <p style={{ margin: "3px 0 0", fontSize: 11, color: textMuted, fontWeight: 500 }}>
-                {s.label}
-              </p>
+              <p style={{ margin: "3px 0 0", fontSize: 11, color: textMuted, fontWeight: 500 }}>{s.label}</p>
             </div>
           </div>
         ))}
       </div>
 
-      {/* Table card */}
-      <div className="um-anim um-d2" style={{ background: cardBg, border: `1px solid ${border}`,
-        borderRadius: 14, overflow: "hidden" }}>
-
+      {/* Table Card */}
+      <div
+        className="um-anim um-d2"
+        style={{
+          background: cardBg,
+          border: `1px solid ${border}`,
+          borderRadius: 14,
+          overflow: "hidden",
+        }}
+      >
         {/* Toolbar */}
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between",
-          padding: "12px 16px", borderBottom: `1px solid ${border}`,
-          background: filterBg, flexWrap: "wrap", gap: 10 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 8,
-            background: cardBg, border: `1px solid ${border}`,
-            borderRadius: 10, padding: "0 12px", height: 38, width: 240 }}>
-            <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
-              <circle cx="7" cy="7" r="5.5" stroke={textMuted} strokeWidth="1.4"/>
-              <path d="M11.5 11.5l2.5 2.5" stroke={textMuted} strokeWidth="1.4" strokeLinecap="round"/>
-            </svg>
-            <input type="text" placeholder="Search by name or email…"
-              value={search} onChange={e => setSearch(e.target.value)}
-              style={{ border: "none", outline: "none", fontSize: 13,
-                background: "transparent", width: "100%",
-                fontFamily: "inherit", color: text }} />
+        <div
+          className="um-toolbar"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "12px 16px",
+            borderBottom: `1px solid ${border}`,
+            background: filterBg,
+            flexWrap: "wrap",
+            gap: 10,
+          }}
+        >
+          <div
+            className="um-search"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              background: cardBg,
+              border: `1px solid ${border}`,
+              borderRadius: 10,
+              padding: "0 12px",
+              height: 38,
+              width: 240,
+            }}
+          >
+            <IconSearch />
+            <input
+              type="text"
+              placeholder="Search by name or email…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              style={{
+                border: "none",
+                outline: "none",
+                fontSize: 13,
+                background: "transparent",
+                width: "100%",
+                fontFamily: "inherit",
+                color: text,
+              }}
+            />
             {search && (
-              <button onClick={() => setSearch("")} style={{ background: "none",
-                border: "none", cursor: "pointer", color: textMuted, padding: 0, display: "flex" }}>
+              <button
+                onClick={() => setSearch("")}
+                style={{ background: "none", border: "none", cursor: "pointer", color: textMuted, padding: 0, display: "flex" }}
+              >
                 <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                  <path d="M2 2l8 8M10 2l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                  <path d="M2 2l8 8M10 2l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
                 </svg>
               </button>
             )}
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
-            <select className="um-select" value={filterRole} onChange={e => setFilterRole(e.target.value)}>
+          <div className="um-sort" style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+            <select className="um-select" value={filterRole} onChange={(e) => setFilterRole(e.target.value)}>
               <option value="all">All Roles</option>
               <option value="superadmin">Superadmins</option>
               <option value="admin">Admins</option>
               <option value="user">Students</option>
               <option value="blocked">Blocked</option>
             </select>
-            <select className="um-select" value={sortBy} onChange={e => setSortBy(e.target.value)}>
+            <select className="um-select" value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
               <option value="lastLogin">Last Login</option>
               <option value="name">Name (A–Z)</option>
               <option value="email">Email (A–Z)</option>
@@ -634,24 +1118,34 @@ export default function UserManagementPage() {
         </div>
 
         {error && (
-          <div style={{ margin: 16, padding: "12px 16px", borderRadius: 10,
-            background: dark ? "rgba(220,38,38,0.1)" : "#fef2f2",
-            border: `1px solid ${dark ? "#7f1d1d" : "#fecaca"}`,
-            color: dark ? "#fca5a5" : "#b91c1c", fontSize: 13 }}>
+          <div
+            style={{
+              margin: 16,
+              padding: "12px 16px",
+              borderRadius: 10,
+              background: dark ? "rgba(220,38,38,0.1)" : "#fef2f2",
+              border: `1px solid ${dark ? "#7f1d1d" : "#fecaca"}`,
+              color: dark ? "#fca5a5" : "#b91c1c",
+              fontSize: 13,
+            }}
+          >
             {error}
           </div>
         )}
 
         {!error && filtered.length === 0 ? (
-          <div style={{ display: "flex", flexDirection: "column", alignItems: "center",
-            justifyContent: "center", padding: "64px 24px", color: textMuted }}>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              padding: "64px 24px",
+              color: textMuted,
+            }}
+          >
             <p style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>
               {search || filterRole !== "all" ? "No users match your filters" : "No users found"}
-            </p>
-            <p style={{ fontSize: 12, color: dark ? "#4b5563" : "#9ca3af" }}>
-              {search || filterRole !== "all"
-                ? "Try clearing your search or filter"
-                : "Users appear here after they log in for the first time."}
             </p>
           </div>
         ) : (
@@ -659,11 +1153,21 @@ export default function UserManagementPage() {
             <table style={{ width: "100%", borderCollapse: "collapse" }}>
               <thead>
                 <tr style={{ background: theadBg }}>
-                  {["User", "Role", "Email", "Last Login", "Actions"].map(h => (
-                    <th key={h} style={{ padding: "10px 16px", textAlign: "left",
-                      fontSize: 11, fontWeight: 700, color: textMuted,
-                      letterSpacing: ".07em", textTransform: "uppercase",
-                      borderBottom: `1px solid ${border}`, whiteSpace: "nowrap" }}>
+                  {["User", "Role", "Email", "Last Login", "Actions"].map((h) => (
+                    <th
+                      key={h}
+                      style={{
+                        padding: "10px 16px",
+                        textAlign: "left",
+                        fontSize: 11,
+                        fontWeight: 700,
+                        color: textMuted,
+                        letterSpacing: ".07em",
+                        textTransform: "uppercase",
+                        borderBottom: `1px solid ${border}`,
+                        whiteSpace: "nowrap",
+                      }}
+                    >
                       {h}
                     </th>
                   ))}
@@ -671,51 +1175,88 @@ export default function UserManagementPage() {
               </thead>
               <tbody>
                 {filtered.map((u, idx) => {
-                  const isMe       = u.email === currentUser?.email;
+                  const isMe = u.email === currentUser?.email;
                   const isTargetSA = u.role === "superadmin";
-                  const badge      = roleBadge(u);
-                  const actions    = getAvailableActions(u);
+                  const badge = roleBadge(u);
+                  const actions = getAvailableActions(u);
 
                   return (
-                    <tr key={u.id || u.email} className="um-row" style={{
-                      borderBottom: `1px solid ${border}`,
-                      animation: "um-slideUp 0.3s ease both",
-                      animationDelay: `${idx * 0.025}s`,
-                      opacity: u.isBlocked ? 0.75 : 1 }}>
-
+                    <tr
+                      key={u.id || u.email}
+                      className="um-row"
+                      style={{
+                        borderBottom: `1px solid ${border}`,
+                        animation: "um-slideUp 0.3s ease both",
+                        animationDelay: `${idx * 0.025}s`,
+                        opacity: u.isBlocked ? 0.7 : 1,
+                      }}
+                    >
                       {/* User */}
                       <td style={{ padding: "14px 16px", verticalAlign: "middle" }}>
                         <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
                           <div style={{ position: "relative", flexShrink: 0 }}>
                             <Avatar user={u} size={36} />
                             {isTargetSA && (
-                              <div style={{ position: "absolute", bottom: -2, right: -2,
-                                width: 14, height: 14, borderRadius: "50%",
-                                background: "#7c3aed", border: `2px solid ${cardBg}`,
-                                display: "flex", alignItems: "center",
-                                justifyContent: "center", fontSize: 8 }}>⚡</div>
+                              <div
+                                style={{
+                                  position: "absolute",
+                                  bottom: -2,
+                                  right: -2,
+                                  width: 14,
+                                  height: 14,
+                                  borderRadius: "50%",
+                                  background: "#7c3aed",
+                                  border: `2px solid ${cardBg}`,
+                                  display: "flex",
+                                  alignItems: "center",
+                                  justifyContent: "center",
+                                }}
+                              >
+                                <IconShield style={{ width: 10, height: 10, color: "#fff" }} />
+                              </div>
                             )}
                           </div>
                           <div style={{ minWidth: 0 }}>
                             <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                              <span style={{ fontSize: 14, fontWeight: 600, color: text,
-                                whiteSpace: "nowrap", overflow: "hidden",
-                                textOverflow: "ellipsis", maxWidth: 160 }}>
+                              <span
+                                style={{
+                                  fontSize: 14,
+                                  fontWeight: 600,
+                                  color: text,
+                                  whiteSpace: "nowrap",
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  maxWidth: 160,
+                                }}
+                              >
                                 {u.displayName || "—"}
                               </span>
                               {isMe && (
-                                <span style={{ fontSize: 9, fontWeight: 700,
-                                  padding: "1px 6px", borderRadius: 999,
-                                  background: dark ? "#1e3a5f" : "#dbeafe",
-                                  color: dark ? "#93c5fd" : "#1d4ed8",
-                                  letterSpacing: ".05em", textTransform: "uppercase",
-                                  whiteSpace: "nowrap" }}>
+                                <span
+                                  style={{
+                                    fontSize: 9,
+                                    fontWeight: 700,
+                                    padding: "1px 6px",
+                                    borderRadius: 999,
+                                    background: dark ? "#1e3a5f" : "#dbeafe",
+                                    color: dark ? "#93c5fd" : "#1d4ed8",
+                                    letterSpacing: ".05em",
+                                    textTransform: "uppercase",
+                                    whiteSpace: "nowrap",
+                                  }}
+                                >
                                   You
                                 </span>
                               )}
                             </div>
-                            <p style={{ margin: 0, fontSize: 11, color: textMuted,
-                              fontFamily: "'DM Mono','Fira Code',monospace" }}>
+                            <p
+                              style={{
+                                margin: 0,
+                                fontSize: 11,
+                                color: textMuted,
+                                fontFamily: "'DM Mono','Fira Code',monospace",
+                              }}
+                            >
                               {u.uid ? `${u.uid.slice(0, 10)}…` : "—"}
                             </p>
                           </div>
@@ -724,89 +1265,90 @@ export default function UserManagementPage() {
 
                       {/* Role badge */}
                       <td style={{ padding: "14px 16px", verticalAlign: "middle" }}>
-                        <span style={{ display: "inline-flex", alignItems: "center",
-                          padding: "4px 10px", borderRadius: 999, fontSize: 11.5, fontWeight: 700,
-                          background: badge.bg, color: badge.color,
-                          border: `1px solid ${badge.border}` }}>
+                        <span
+                          style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            gap: 6,
+                            padding: "4px 10px",
+                            borderRadius: 999,
+                            fontSize: 11.5,
+                            fontWeight: 700,
+                            background: badge.bg,
+                            color: badge.color,
+                            border: `1px solid ${badge.color}40`,
+                          }}
+                        >
+                          {badge.icon}
                           {badge.label}
                         </span>
                       </td>
 
                       {/* Email */}
                       <td style={{ padding: "14px 16px", verticalAlign: "middle" }}>
-                        <span style={{ fontSize: 13, color: textMuted,
-                          fontFamily: "'DM Mono','Fira Code',monospace" }}>
+                        <span
+                          style={{
+                            fontSize: 13,
+                            color: textMuted,
+                            fontFamily: "'DM Mono','Fira Code',monospace",
+                          }}
+                        >
                           {u.email}
                         </span>
                       </td>
 
-                      {/* Last Login */}
+                      {/* Last login */}
                       <td style={{ padding: "14px 16px", verticalAlign: "middle" }}>
-                        <span style={{ fontSize: 12.5, color: textMuted }}>
-                          {timeAgo(u.lastLogin)}
-                        </span>
+                        <span style={{ fontSize: 12.5, color: textMuted }}>{timeAgo(u.lastLogin)}</span>
                       </td>
 
-                      {/* Actions */}
+                      {/* Actions (icon-only) */}
                       <td style={{ padding: "14px 16px", verticalAlign: "middle" }}>
                         {isMe ? (
-                          <span style={{ fontSize: 11.5, color: dark ? "#475569" : "#d1d5db",
-                            fontStyle: "italic" }}>(you)</span>
+                          <span style={{ fontSize: 11.5, color: dark ? "#475569" : "#d1d5db", fontStyle: "italic" }}>(you)</span>
                         ) : isTargetSA ? (
-                          <span style={{ fontSize: 11.5, color: dark ? "#475569" : "#d1d5db",
-                            fontStyle: "italic" }}>Protected</span>
+                          <span style={{ fontSize: 11.5, color: dark ? "#475569" : "#d1d5db", fontStyle: "italic" }}>Protected</span>
                         ) : (
-                          <div style={{ display: "flex", gap: 5, flexWrap: "wrap" }}>
+                          <div style={{ display: "flex", gap: 5, alignItems: "center" }}>
                             {actions.canPromote && (
-                              <button className="um-action-btn"
+                              <button
+                                className="um-action-icon"
                                 onClick={() => openConfirm(u, "promote")}
-                                style={{ background: dark ? "#1e3a5f" : "#eff6ff",
-                                  color: dark ? "#93c5fd" : "#1d4ed8",
-                                  border: `1px solid ${dark ? "#1d4ed8" : "#bfdbfe"}` }}>
-                                ⭐ Make Admin
+                                title="Promote to Admin"
+                                style={{color: "#b45309" }}
+                              >
+                                <IconUser />
                               </button>
                             )}
                             {actions.canDemote && (
-                              <button className="um-action-btn"
+                              <button
+                                className="um-action-icon"
                                 onClick={() => openConfirm(u, "demote")}
-                                style={{ background: dark ? "#2d1f07" : "#fffbeb",
-                                  color: dark ? "#fcd34d" : "#b45309",
-                                  border: `1px solid ${dark ? "#854d0e" : "#fde68a"}` }}>
-                                👤 Remove Admin
+                                title="Revert to Admin"
+                                style={{ color: "#b45309" }}
+                              >
+                                <IconUser />
                               </button>
                             )}
                             {actions.canBlock && (
-                              <button className="um-action-btn"
+                              <button
+                                className="um-action-icon"
                                 onClick={() => openConfirm(u, "block")}
-                                style={{ background: dark ? "#2d1f07" : "#fffbeb",
-                                  color: dark ? "#fbbf24" : "#b45309",
-                                  border: `1px solid ${dark ? "#92400e" : "#fde68a"}` }}>
-                                🚫 Block
+                                title="Block User"
+                                style={{ color: "#b45309" }}
+                              >
+                                <IconBan />
                               </button>
                             )}
                             {actions.canUnblock && (
-                              <button className="um-action-btn"
+                              <button
+                                className="um-action-icon"
                                 onClick={() => openConfirm(u, "unblock")}
-                                style={{ background: dark ? "#14301f" : "#f0fdf4",
-                                  color: dark ? "#86efac" : "#15803d",
-                                  border: `1px solid ${dark ? "#166534" : "#bbf7d0"}` }}>
-                                ✅ Unblock
+                                title="Unblock User"
+                                style={{ color: "#15803d" }}
+                              >
+                                <IconCheck />
                               </button>
-                            )}
-                            {actions.canDelete && (
-                              <button className="um-action-btn"
-                                onClick={() => openConfirm(u, "delete")}
-                                style={{ background: dark ? "#2d0a14" : "#fff1f2",
-                                  color: dark ? "#fca5a5" : "#be123c",
-                                  border: `1px solid ${dark ? "#7f1d1d" : "#fecdd3"}` }}>
-                                🗑️ Delete
-                              </button>
-                            )}
-                            {!actions.canPromote && !actions.canDemote &&
-                             !actions.canBlock && !actions.canUnblock && !actions.canDelete && (
-                              <span style={{ fontSize: 11.5,
-                                color: dark ? "#475569" : "#d1d5db",
-                                fontStyle: "italic" }}>No actions</span>
                             )}
                           </div>
                         )}
@@ -820,7 +1362,13 @@ export default function UserManagementPage() {
         )}
 
         {filtered.length > 0 && (
-          <div style={{ padding: "10px 16px", borderTop: `1px solid ${border}`, background: filterBg }}>
+          <div
+            style={{
+              padding: "10px 16px",
+              borderTop: `1px solid ${border}`,
+              background: filterBg,
+            }}
+          >
             <p style={{ margin: 0, fontSize: 11, color: textMuted }}>
               Showing {filtered.length} of {users.length} registered user{users.length !== 1 ? "s" : ""}
             </p>
@@ -837,10 +1385,14 @@ export default function UserManagementPage() {
         loading={actionLoading}
         dark={dark}
       />
+
       <AddAdminModal
         isOpen={addAdminOpen}
         onClose={() => setAddAdminOpen(false)}
-        onAdded={(email) => { showToast(`${email} added as Admin.`); fetchUsers(); }}
+        onAdded={(email) => {
+          showToast(`${email} added as Admin.`);
+          fetchUsers();
+        }}
         dark={dark}
       />
     </div>

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -4,10 +4,10 @@ import {
 } from "firebase/firestore";
 import { db } from "../lib/firebaseClient";
 
+// ── Get all users ─────────────────────────────────────────────────────────
 export async function getAllUsers() {
   const snapshot = await getDocs(collection(db, "users"));
   const users = snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
-
   return users.sort((a, b) => {
     const da  = a.lastLogin?.toDate?.() ?? new Date(a.lastLogin ?? 0);
     const db_ = b.lastLogin?.toDate?.() ?? new Date(b.lastLogin ?? 0);
@@ -15,39 +15,42 @@ export async function getAllUsers() {
   });
 }
 
-export async function upsertUser(user) {
-  const userRef = doc(db, "users", user.email);
-  const userDoc = await getDoc(userRef);
+// ── Get role of a single user by email ────────────────────────────────────
+export async function getUserRole(email) {
+  const userSnap = await getDoc(doc(db, "users", email));
+  if (!userSnap.exists()) return null;
+  return userSnap.data().role || "user";
+}
 
-  if (userDoc.exists()) {
-    // ── Existing user: only refresh profile info and lastLogin
-    // Never overwrite role — it's managed by promote/demote
-    await setDoc(
-      userRef,
-      {
-        displayName: user.displayName || "",
-        photoURL:    user.photoURL    || "",
-        uid:         user.uid,
-        lastLogin:   new Date(),
-      },
-      { merge: true }
-    );
+// ── Upsert user on login ──────────────────────────────────────────────────
+export async function upsertUser(firebaseUser) {
+  const email = firebaseUser.email;
+  const userRef = doc(db, "users", email);
+  const userSnap = await getDoc(userRef);
+  const now = new Date();
+
+  const profileData = {
+    displayName: firebaseUser.displayName || "",
+    photoURL:    firebaseUser.photoURL    || "",
+    uid:         firebaseUser.uid,
+    lastLogin:   now,
+  };
+
+  if (userSnap.exists()) {
+    await setDoc(userRef, profileData, { merge: true });
   } else {
-    // ── New user: create doc with default role "user"
     await setDoc(userRef, {
-      email:       user.email,
-      displayName: user.displayName || "",
-      photoURL:    user.photoURL    || "",
-      uid:         user.uid,
-      role:        "user",          // ← always "user" for new registrations
-      lastLogin:   new Date(),
-      createdAt:   new Date(),
+      email,
+      role:      "user",
+      isBlocked: false,
+      createdAt: now,
+      ...profileData,
     });
   }
 }
 
+// ── Promote to admin ──────────────────────────────────────────────────────
 export async function promoteToAdmin(email) {
-  await setDoc(doc(db, "admins", email), { promotedAt: new Date() });
   await setDoc(
     doc(db, "users", email),
     { role: "admin", updatedAt: new Date() },
@@ -55,11 +58,52 @@ export async function promoteToAdmin(email) {
   );
 }
 
+// ── Demote to user ────────────────────────────────────────────────────────
 export async function demoteFromAdmin(email) {
-  await deleteDoc(doc(db, "admins", email));
   await setDoc(
     doc(db, "users", email),
     { role: "user", updatedAt: new Date() },
     { merge: true }
   );
+}
+
+// ── Add admin by email ────────────────────────────────────────────────────
+export async function addAdminByEmail(email) {
+  const userRef  = doc(db, "users", email);
+  const userSnap = await getDoc(userRef);
+  if (userSnap.exists()) {
+    await setDoc(userRef, { role: "admin", updatedAt: new Date() }, { merge: true });
+  } else {
+    await setDoc(userRef, {
+      email,
+      role:        "admin",
+      isBlocked:   false,
+      createdAt:   new Date(),
+      displayName: "",
+      photoURL:    "",
+      uid:         "",
+    });
+  }
+}
+
+// ── Block / Unblock ───────────────────────────────────────────────────────
+export async function blockUser(email) {
+  await setDoc(
+    doc(db, "users", email),
+    { isBlocked: true, blockedAt: new Date() },
+    { merge: true }
+  );
+}
+
+export async function unblockUser(email) {
+  await setDoc(
+    doc(db, "users", email),
+    { isBlocked: false, blockedAt: null },
+    { merge: true }
+  );
+}
+
+// ── Delete user ───────────────────────────────────────────────────────────
+export async function deleteUser(email) {
+  await deleteDoc(doc(db, "users", email));
 }

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,0 +1,65 @@
+import {
+  collection, getDocs, doc, setDoc,
+  deleteDoc, getDoc,
+} from "firebase/firestore";
+import { db } from "../lib/firebaseClient";
+
+export async function getAllUsers() {
+  const snapshot = await getDocs(collection(db, "users"));
+  const users = snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
+
+  return users.sort((a, b) => {
+    const da  = a.lastLogin?.toDate?.() ?? new Date(a.lastLogin ?? 0);
+    const db_ = b.lastLogin?.toDate?.() ?? new Date(b.lastLogin ?? 0);
+    return db_ - da;
+  });
+}
+
+export async function upsertUser(user) {
+  const userRef = doc(db, "users", user.email);
+  const userDoc = await getDoc(userRef);
+
+  if (userDoc.exists()) {
+    // ── Existing user: only refresh profile info and lastLogin
+    // Never overwrite role — it's managed by promote/demote
+    await setDoc(
+      userRef,
+      {
+        displayName: user.displayName || "",
+        photoURL:    user.photoURL    || "",
+        uid:         user.uid,
+        lastLogin:   new Date(),
+      },
+      { merge: true }
+    );
+  } else {
+    // ── New user: create doc with default role "user"
+    await setDoc(userRef, {
+      email:       user.email,
+      displayName: user.displayName || "",
+      photoURL:    user.photoURL    || "",
+      uid:         user.uid,
+      role:        "user",          // ← always "user" for new registrations
+      lastLogin:   new Date(),
+      createdAt:   new Date(),
+    });
+  }
+}
+
+export async function promoteToAdmin(email) {
+  await setDoc(doc(db, "admins", email), { promotedAt: new Date() });
+  await setDoc(
+    doc(db, "users", email),
+    { role: "admin", updatedAt: new Date() },
+    { merge: true }
+  );
+}
+
+export async function demoteFromAdmin(email) {
+  await deleteDoc(doc(db, "admins", email));
+  await setDoc(
+    doc(db, "users", email),
+    { role: "user", updatedAt: new Date() },
+    { merge: true }
+  );
+}


### PR DESCRIPTION
### What does this page do and who is it for?
This page allows **admins and superadmins** to manage all user accounts.  
- **Superadmins** see all users and can promote/demote admins, block/unblock, add admins by email.  
- **Admins** see only regular students and can only block/unblock them.  
- The page includes search, role‑based tabs, secure action buttons, and real‑time updates.

### What design decisions did you make and why?
- **Tabbed filtering** (All / Admins / Students / Blocked) – faster than a dropdown.  
- **Icon‑only action buttons** (Shield, User, Ban, Check) – compact, professional, with tooltips.  
- **Responsive grid** (4→2 columns on mobile, 375px) – ensures usability on small screens.  
- **Transparent backdrop + solid pop‑up card** – keeps focus without hiding the page completely; each action shows a clear message and hint.  
- **Role‑based data filtering** – admins never see other admins/superadmins, preventing privilege leaks.

### How did you test it?
- **Superadmin** – verified promote, demote, block, unblock, add admin; confirmed Firestore updates.  
- **Admin** – confirmed only student accounts appear, only block/unblock buttons shown.  
- **Search & filters** – tested all tab combinations and search queries; results correct.  
- **Responsive** – Chrome DevTools at 375px, 768px, 1920px; layout adapts without breakage.  
- **Blocked users** – verified they cannot sign in (AuthContext) and unblock restores access.